### PR TITLE
플랜결제정보 모달 / 문구 변경, 다음 결제일 추가, 적용기간 수정

### DIFF
--- a/src/clients/private/_modals/SelectPlanModal/PaymentPreviewModal/PaymentPreviewActiveRange.tsx
+++ b/src/clients/private/_modals/SelectPlanModal/PaymentPreviewModal/PaymentPreviewActiveRange.tsx
@@ -4,21 +4,21 @@ import {ScordiPlanDto} from '^models/_scordi/ScordiPlan/type';
 import {ScordiSubscriptionDto} from '^models/_scordi/ScordiSubscription/type';
 
 interface PaymentPreviewActiveRangeProps {
-    startDate: string;
-    nextDate: string;
+    startDate: Date;
+    finishDate: Date | null;
 }
 
 export const PaymentPreviewActiveRange = memo((props: PaymentPreviewActiveRangeProps) => {
-    const {startDate, nextDate} = props;
+    const {startDate, finishDate} = props;
 
     return (
         <div className="text-right">
             <div className="flex items-center gap-2">
-                <span className="font-medium">{startDate}</span>
+                <span className="font-medium">{yyyy_mm_dd(startDate)}</span>
                 <span>~</span>
-                {nextDate && <span>{nextDate}</span>}
+                {finishDate && <span>{yyyy_mm_dd(finishDate)}</span>}
             </div>
-            {startDate !== yyyy_mm_dd(new Date()) && (
+            {yyyy_mm_dd(startDate) !== yyyy_mm_dd(new Date()) && (
                 <div className="text-gray-400 text-12">다음 주기부터 적용 예정</div>
             )}
         </div>

--- a/src/clients/private/_modals/SelectPlanModal/PaymentPreviewModal/PaymentPreviewActiveRange.tsx
+++ b/src/clients/private/_modals/SelectPlanModal/PaymentPreviewModal/PaymentPreviewActiveRange.tsx
@@ -4,39 +4,24 @@ import {ScordiPlanDto} from '^models/_scordi/ScordiPlan/type';
 import {ScordiSubscriptionDto} from '^models/_scordi/ScordiSubscription/type';
 
 interface PaymentPreviewActiveRangeProps {
-    plan: ScordiPlanDto;
-    currentSubscription: ScordiSubscriptionDto | null;
+    startDate: string;
+    nextDate: string;
 }
 
 export const PaymentPreviewActiveRange = memo((props: PaymentPreviewActiveRangeProps) => {
-    const {plan, currentSubscription} = props;
-
-    const startDate = getStartDate(plan, currentSubscription);
-    const nextDate = plan.getNextDate(startDate);
+    const {startDate, nextDate} = props;
 
     return (
         <div className="text-right">
             <div className="flex items-center gap-2">
-                <span className="font-medium">{yyyy_mm_dd(startDate)}</span>
+                <span className="font-medium">{startDate}</span>
                 <span>~</span>
-                {nextDate && <span>{yyyy_mm_dd(nextDate)}</span>}
+                {nextDate && <span>{nextDate}</span>}
             </div>
-            {yyyy_mm_dd(startDate) !== yyyy_mm_dd(new Date()) && (
+            {startDate !== yyyy_mm_dd(new Date()) && (
                 <div className="text-gray-400 text-12">다음 주기부터 적용 예정</div>
             )}
         </div>
     );
 });
 PaymentPreviewActiveRange.displayName = 'PaymentPreviewActiveRange';
-
-function getStartDate(plan: ScordiPlanDto, currentSubscription: ScordiSubscriptionDto | null) {
-    const now = new Date();
-
-    if (!currentSubscription) return now;
-
-    if (currentSubscription.scordiPlan.priority > plan.priority || currentSubscription.scordiPlan.price > plan.price) {
-        return currentSubscription.getNextDate() || now;
-    }
-
-    return now;
-}

--- a/src/clients/private/_modals/SelectPlanModal/PaymentPreviewModal/PaymentPreviewModalContent.tsx
+++ b/src/clients/private/_modals/SelectPlanModal/PaymentPreviewModal/PaymentPreviewModalContent.tsx
@@ -1,12 +1,12 @@
 import React, {memo} from 'react';
-import {ScordiPlanDto, t_planStepType} from '^models/_scordi/ScordiPlan/type';
+import {ScordiPlanDto} from '^models/_scordi/ScordiPlan/type';
 import {ScordiSubscriptionDto} from '^models/_scordi/ScordiSubscription/type';
 import {ScordiPaymentMethodDto} from '^models/_scordi/ScordiPaymentMethod/type';
+import {dayBefore, yyyy_mm_dd} from '^utils/dateTime';
 import {KeyValue} from './KeyValue';
 import {PaymentPreviewActiveRange} from './PaymentPreviewActiveRange';
 import {PaymentMethodCard} from './PaymentMethodCard';
 import {PriceTextWithStepSize} from './PriceTextWithStepSize';
-import {yyyy_mm_dd} from '^utils/dateTime';
 
 interface PaymentPreviewModalSubmitButtonProps {
     plan: ScordiPlanDto;
@@ -17,17 +17,14 @@ interface PaymentPreviewModalSubmitButtonProps {
 export const PaymentPreviewModalContent = memo((props: PaymentPreviewModalSubmitButtonProps) => {
     const {plan, currentSubscription, paymentMethod} = props;
 
+    // 구독 시작일
     const startDate = getStartDate(plan, currentSubscription);
 
+    // 다음 결제일 : 플랜의 스펙을 구성하기에 따라 만료되지 않는 경우가 존재 할 수 있고, 이 경우 null 값을 반환합니다.
     const nextDate = plan.getNextDate(startDate);
 
-    if (!nextDate) return <></>;
-
-    const finshDate = () => {
-        const updateDate = new Date(nextDate);
-        updateDate.setDate(nextDate.getDate() - 1);
-        return updateDate || '';
-    };
+    // 구독 종료일 : '다음 결제일' 이 null 값인 경우, 구독 종료일 역시 의미가 없기에 마찬가지로 null 을 반환합니다.
+    const finishDate = nextDate ? dayBefore(1, nextDate) : null;
 
     return (
         <section className="bg-[#f9f9f9] rounded-lg p-5">
@@ -62,7 +59,7 @@ export const PaymentPreviewModalContent = memo((props: PaymentPreviewModalSubmit
                 <hr />
 
                 <KeyValue label="적용 기간">
-                    <PaymentPreviewActiveRange startDate={yyyy_mm_dd(startDate)} nextDate={yyyy_mm_dd(finshDate())} />
+                    <PaymentPreviewActiveRange startDate={startDate} finishDate={finishDate} />
                 </KeyValue>
 
                 {nextDate && (

--- a/src/clients/private/_modals/SelectPlanModal/PaymentPreviewModal/PaymentPreviewModalHeader.tsx
+++ b/src/clients/private/_modals/SelectPlanModal/PaymentPreviewModal/PaymentPreviewModalHeader.tsx
@@ -13,7 +13,7 @@ export const PaymentPreviewModalHeader = memo((props: PaymentPreviewModalHeaderP
         <header className={`flex justify-between items-start ${className}`}>
             <div>
                 <h3 className="text-2xl mb-1.5">플랜 결제 정보</h3>
-                <p className="text-[#999] font-medium text-16">플랜 결제 정보를 확인해보세요.</p>
+                <p className="text-[#999] font-medium text-16">아래의 내용으로 지금 결제할까요?</p>
             </div>
 
             <div>

--- a/src/models/_scordi/ScordiPlan/type/ScordiPlan.dto.ts
+++ b/src/models/_scordi/ScordiPlan/type/ScordiPlan.dto.ts
@@ -25,6 +25,7 @@ export class ScordiPlanDto {
     @TypeCast(() => Date) createdAt: Date; // 생성일시
     @TypeCast(() => Date) updatedAt: Date; // 수정일시
 
+    // 다음 결제일 계산 : 플랜의 스펙을 구성하기에 따라 만료되지 않는 경우가 존재 할 수 있고, 이 경우 null 값을 반환합니다.
     getNextDate(startDate: Date) {
         if (this.stepType === ScordiPlanStepType.Month) {
             return monthAfter(this.stepSize, startDate);


### PR DESCRIPTION
## ✨ 개발 주요 내용

```
- 문구 변경, (플랜 결제 정보를 확인해보세요 => 아래의 내용으로 지금 결제할까요? )
- 다음 결제일 추가 
- 적용 기간 수정 (ex. 24.11.11 ~ 24.12.11 -> 24.11.11 ~ 24.11.10   )
```