### PR TITLE
구독상세 페이지 QA 일부 해결 (멤버탭, 정보탭)

### DIFF
--- a/src/clients/private/_components/table/ListTable/ListTable.tsx
+++ b/src/clients/private/_components/table/ListTable/ListTable.tsx
@@ -14,6 +14,9 @@ interface ListTableProps<Dto> {
     // reload: () => Promise<any>;
     // orderBy: (sortKey: string, value: ("ASC" | "DESC")) => Promise<any>;
 
+    // Use to prevent truncation of popup components (such as date pickers).
+    addBottomPadding?: boolean;
+
     // Components
     Header?: ReactComponentLike;
     Row: (props: {item: Dto}) => JSX.Element;
@@ -21,7 +24,7 @@ interface ListTableProps<Dto> {
 
 export const ListTable = <Dto,>(props: ListTableProps<Dto>) => {
     const router = useRouter();
-    const {onReady, isLoading, items} = props;
+    const {onReady, isLoading, items, addBottomPadding = false} = props;
     const {Header, Row} = props;
 
     useEffect(() => {
@@ -43,6 +46,8 @@ export const ListTable = <Dto,>(props: ListTableProps<Dto>) => {
                         {items.map((item, i) => (
                             <Row key={i} item={item} />
                         ))}
+
+                        {addBottomPadding && items.length <= 6 && <tr className="h-[400px] w-full"></tr>}
                     </tbody>
                 </Table>
             </div>

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionInfoTab/SubscriptionPaymentInfoSection/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionInfoTab/SubscriptionPaymentInfoSection/index.tsx
@@ -206,7 +206,9 @@ export const SubscriptionPaymentInfoSection = memo(() => {
                                             const finishAt = newValue?.startDate;
                                             if (finishAt) {
                                                 const startAt = form.watch('startAt');
-                                                if (startAt && !dateIsBeforeThen(startAt, finishAt)) {
+                                                if (!startAt) {
+                                                    toast('시작일을 먼저 설정해주세요.');
+                                                } else if (startAt && !dateIsBeforeThen(startAt, finishAt)) {
                                                     toast('시작일보다는 커야 합니다.');
                                                     form.setValue('finishAt', form.watch('finishAt'));
                                                 } else {

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableHeader.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableHeader.tsx
@@ -21,9 +21,7 @@ export const TeamMemberInSubscriptionTableHeader = memo((props: TeamMemberInSubs
 
             <th>이메일 계정</th>
 
-            <th>계정부여일</th>
-
-            <th>계정회수(예정)일</th>
+            <th>계정부여(예정)일 ~ 계정회수(예정)일</th>
 
             <th>비고</th>
 

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableRow.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableRow.tsx
@@ -82,8 +82,8 @@ export const TeamMemberInSubscriptionTableRow = memo((props: TeamMemberInSubscri
                         className={`flex items-center gap-2 px-3 -mx-3 text-gray-700 group-hover:text-scordi max-w-sm`}
                     >
                         <TeamMemberAvatar teamMember={teamMember} className="w-8 h-8" />
-                        <div className="overflow-x-hidden">
-                            <p className="truncate text-14">
+                        <div>
+                            <p className="text-14">
                                 <span>{teamMember.name}</span>
                             </p>
                         </div>

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableRow.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableRow.tsx
@@ -32,6 +32,11 @@ export const TeamMemberInSubscriptionTableRow = memo((props: TeamMemberInSubscri
     const [isLoading, setIsLoading] = useState(false);
     const {seat, onClick, reload} = props;
 
+    const [seatDateValue, setSeatDateValue] = useState({
+        startDate: seat.startAt || null,
+        endDate: seat.finishAt || null,
+    });
+
     if (!seat.teamMember || !subscription) return null;
 
     const hoverBgColor = 'group-hover:bg-scordi-light-50 transition-all';
@@ -108,42 +113,24 @@ export const TeamMemberInSubscriptionTableRow = memo((props: TeamMemberInSubscri
                 </p>
             </td>
 
-            {/* 계정부여일 */}
+            {/* 계정부여(예정)일 ~ 계정회수(예정)일 */}
             <td className={` ${hoverBgColor} ${loadingStyle}`}>
                 <Datepicker
-                    inputClassName="input px-1.5 py-1 rounded-md w-auto input-sm input-ghost h-[32px] leading-[32px] inline-flex items-center focus:bg-slate-100 focus:outline-1 focus:outline-offset-0 text-gray-400"
+                    containerClassName="min-w-[220px] relative"
+                    inputClassName="input px-1.5 py-1 rounded-md w-full input-sm input-ghost h-[32px] leading-[32px] inline-flex items-center focus:bg-slate-100 focus:outline-1 focus:outline-offset-0 text-gray-400"
                     toggleClassName={`${seat.finishAt ? '' : 'hidden'}`}
                     toggleIcon={() => <FiMinusCircle />}
-                    asSingle={true}
-                    useRange={false}
-                    placeholder={seat.startAt ? yyyy_mm_dd(seat.startAt) : '-'}
-                    value={{
-                        startDate: seat.startAt || null,
-                        endDate: seat.startAt || null,
-                    }}
+                    useRange={true}
+                    placeholder={`${seat.startAt ? yyyy_mm_dd(seat.startAt) : ''} ~ ${
+                        seat.finishAt ? yyyy_mm_dd(seat.finishAt) : ''
+                    }`}
+                    minDate={new Date()}
+                    value={seatDateValue}
                     onChange={async (newValue) => {
-                        if (seat.startAt === newValue?.startDate) return;
-                        return update({startAt: newValue?.startDate});
-                    }}
-                />
-            </td>
+                        if (!newValue?.startDate || !newValue?.endDate) return;
 
-            {/* 계정회수일 */}
-            <td className={` ${hoverBgColor} ${loadingStyle}`}>
-                <Datepicker
-                    inputClassName="input px-1.5 py-1 rounded-md w-auto input-sm input-ghost h-[32px] leading-[32px] inline-flex items-center focus:bg-slate-100 focus:outline-1 focus:outline-offset-0 text-gray-400"
-                    toggleClassName={`${seat.finishAt ? '' : 'hidden'}`}
-                    toggleIcon={() => <FiMinusCircle />}
-                    asSingle={true}
-                    useRange={false}
-                    placeholder={seat.finishAt ? yyyy_mm_dd(seat.finishAt) : '-'}
-                    value={{
-                        startDate: seat.finishAt || null,
-                        endDate: seat.finishAt || null,
-                    }}
-                    onChange={async (newValue) => {
-                        if (seat.finishAt === newValue?.startDate) return;
-                        return update({finishAt: newValue?.startDate});
+                        setSeatDateValue(newValue);
+                        return update({startAt: newValue?.startDate, finishAt: newValue?.endDate});
                     }}
                 />
             </td>

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
@@ -132,6 +132,7 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
                 <ListTable
                     items={result.items}
                     isLoading={false}
+                    addBottomPadding={true}
                     Header={() => <TeamMemberInSubscriptionTableHeader orderBy={orderBy} />}
                     Row={({item}) => <TeamMemberInSubscriptionTableRow seat={item} reload={onPageReload} />}
                 />


### PR DESCRIPTION
# Summary

아래 QA 이슈들 해결

- [[구독상세p] 멤버탭> 멤버 이름이 테이블에서 짤리지 않도록 수정](https://www.notion.so/01republic/p-1961aa2520df80e79c40eea1bd2ad576?pvs=4)
- [[구독상세p] 멤버탭 > 멤버테이블에서 최상단에 있는 멤버의 계정부여일/계정회수일 수정 시, 캘린더가 짤려서 보이는 버그](https://www.notion.so/01republic/p-1961aa2520df80bc9724f75826b1f77d?pvs=4)
- [[구독상세p] 멤버탭 > 계정부여일보다 계정회수일이 과거일자로 설정되는 경우, 알럿을 띄워주기](https://www.notion.so/01republic/p-1961aa2520df802da74fc1beacd24f48?pvs=4)
- [[구독상세p] 멤버탭 > 계정부여일이 없는 상태에서, 계정회수일을 먼저 설정할 수 없도록 수정](https://www.notion.so/01republic/p-1961aa2520df801282dbe61742a81be8?pvs=4)
  - 위 티켓 세개는 한꺼번에 해결했는데요, 첨부한 사진처럼 그냥 table column 두개를 합치고 Range로 설정할 수 있도록 만들었어요. (이렇게 해도 되는지는 모르겠지만...)
  - 잘리는 이슈는 정상적인 방법으로 도저히 해결이 불가능해서, table row 수가 7개 이하일 때는 아래쪽에 여백이 생기도록 만들었어요. 진짜 빅 꼼수라 정말 이러고 싶지는 않았지만... 그나마 가장 쉬운 해결책인 듯 해요.
  


- [[구독상세p] 정보탭 > 결제정보 - 구독 시작일이 없는 경우 구독 종료일만을 추가할 수 없음](https://www.notion.so/01republic/p-1981aa2520df80a7a579eaeceb1a44d6?pvs=4)
  - 이거 픽스는 했는데... 첨부한 두번째 사진처럼 에러 이후에 셀렉이 남아버리는 이슈가 있네요. 라이브러리 자체 이슈인 듯 한데 지금은 방법이 없기도 하고 큰 이슈는 아니라서 냅두면 될 것 같아용

# Note