### PR TITLE
[구독 상세 페이지 > 멤버 탭] 여러 멤버를 선택하고 제외할 수 있도록 수정, 멤버 연결하기 페이지에서 검색이 가능하도록 수정

### DIFF
--- a/src/clients/private/_components/table/ListTable/ListTableContainer.tsx
+++ b/src/clients/private/_components/table/ListTable/ListTableContainer.tsx
@@ -23,6 +23,7 @@ interface ListTableContainerProps extends WithChildren {
 
     // components
     Layout?: ReactComponentLike;
+    TopMenu?: ReactComponentLike;
 
     /**
      * Empty State
@@ -36,7 +37,7 @@ interface ListTableContainerProps extends WithChildren {
 
 export const ListTableContainer = memo((props: ListTableContainerProps) => {
     const {pagination, movePage, changePageSize} = props;
-    const {Layout = CardContainerTableLayout} = props;
+    const {Layout = CardContainerTableLayout, TopMenu} = props;
     const {unit = '개', hideTopPaginator = false, hideBottomPaginator = false} = props;
     const {isLoading = false, isNotLoaded = false, isEmptyResult = false} = props;
     const {children} = props;
@@ -62,7 +63,7 @@ export const ListTableContainer = memo((props: ListTableContainerProps) => {
         <Layout>
             {!hideTopPaginator && (
                 <div className="flex items-center justify-between mb-4">
-                    <div></div>
+                    {TopMenu ? <TopMenu /> : <div />}
                     <ListTablePaginator
                         pagination={pagination}
                         movePage={movePage}

--- a/src/clients/private/_modals/SlideUpAllSelectModal/index.tsx
+++ b/src/clients/private/_modals/SlideUpAllSelectModal/index.tsx
@@ -81,8 +81,6 @@ export const SlideUpAllSelectModal = <T,>(props: SlideUpAllSelectModalProps<T>) 
         }
     }, [isOpened]);
 
-    console.log(items.length);
-
     return (
         <SlideUpModal open={isOpened} onClose={onClose} size="md" modalClassName="rounded-none sm:rounded-t-box p-0">
             <div className="flex items-center">

--- a/src/clients/private/_modals/SlideUpAllSelectModal/index.tsx
+++ b/src/clients/private/_modals/SlideUpAllSelectModal/index.tsx
@@ -2,8 +2,7 @@ import React, {useEffect, useState} from 'react';
 import {SlideUpModal} from '^components/modals/_shared/SlideUpModal';
 import {LoadableBox} from '^components/util/loading';
 import {toast} from 'react-hot-toast';
-import {ReactComponentLike} from 'prop-types';
-import {ChevronLeft} from 'lucide-react';
+import {ChevronLeft, Search} from 'lucide-react';
 
 interface SlideUpAllSelectModalProps<T> {
     /**
@@ -40,12 +39,14 @@ export const SlideUpAllSelectModal = <T,>(props: SlideUpAllSelectModalProps<T>) 
     const {titleCaption = '', title, ctaInactiveText = '', ctaActiveText = '', successMessage = '연결했어요.'} = props;
     const [selectedIds, setSelectedIds] = useState<number[]>([]);
     const [isAllSelect, setIsAllSelect] = useState(false);
+    const [searchTerm, setSearchTerm] = useState<string>('');
 
     const onOpened = () => _onOpened && _onOpened();
 
     const onClosed = () => {
         _onClosed && _onClosed();
         setSelectedIds([]);
+        setSearchTerm('');
     };
 
     const toggleSelect = (id: number) => {
@@ -102,17 +103,43 @@ export const SlideUpAllSelectModal = <T,>(props: SlideUpAllSelectModalProps<T>) 
                 </div>
             </div>
 
-            <div className="px-6 pt-6">
+            <div className="relative w-[calc(100%-3rem)] mx-6 mt-6">
+                <input
+                    type="text"
+                    placeholder="검색어를 입력하세요"
+                    className="w-full border rounded-md border-gray-300 pl-10 pr-4 py-2"
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                />
+                <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                    <Search size={18} className="text-gray-400" />
+                </div>
+            </div>
+
+            <div className="px-6 pt-4">
                 <div className="-mx-6 px-6 sm:max-h-[60vh] sm:min-h-[40vh] overflow-auto no-scrollbar">
                     <LoadableBox isLoading={isLoading} loadingType={2} noPadding>
-                        {items.map((item, i) => (
-                            <Row
-                                key={i}
-                                item={item}
-                                onClick={(selected) => toggleSelect(getId(selected))}
-                                isSelected={selectedIds.includes(getId(item))}
-                            />
-                        ))}
+                        {items
+                            .filter((item) => {
+                                if (!searchTerm.trim()) return true;
+                                const itemString = JSON.stringify(item).toLowerCase();
+                                return itemString.includes(searchTerm.toLowerCase());
+                            })
+                            .map((item, i) => (
+                                <Row
+                                    key={i}
+                                    item={item}
+                                    onClick={(selected) => toggleSelect(getId(selected))}
+                                    isSelected={selectedIds.includes(getId(item))}
+                                />
+                            ))}
+                        {searchTerm &&
+                            items.filter((item) => {
+                                const itemString = JSON.stringify(item).toLowerCase();
+                                return itemString.includes(searchTerm.toLowerCase());
+                            }).length === 0 && (
+                                <div className="py-8 text-center text-gray-500 text-sm">검색 결과가 없습니다.</div>
+                            )}
                     </LoadableBox>
                 </div>
             </div>

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableHeader.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableHeader.tsx
@@ -2,14 +2,25 @@ import React, {memo} from 'react';
 import {SortableTH} from '^v3/share/table/columns/share/SortableTH';
 import {ListTableHeaderProps} from '^clients/private/_components/table/ListTable/types';
 
-interface TeamMemberInSubscriptionTableHeaderProps extends ListTableHeaderProps {}
+interface TeamMemberInSubscriptionTableHeaderProps extends ListTableHeaderProps {
+    allSelected: boolean;
+    onAllSelect: () => any;
+}
 
 export const TeamMemberInSubscriptionTableHeader = memo((props: TeamMemberInSubscriptionTableHeaderProps) => {
     const {orderBy} = props;
+    const {allSelected, onAllSelect} = props;
 
     return (
         <tr className="bg-slate-100">
-            <th></th>
+            <th>
+                <input
+                    type="checkbox"
+                    className="w-4 h-4 focus:ring-0 cursor-pointer"
+                    checked={allSelected}
+                    onChange={onAllSelect}
+                />
+            </th>
 
             <SortableTH sortKey="[name]" onClick={orderBy}>
                 이름

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableHeader.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableHeader.tsx
@@ -9,6 +9,8 @@ export const TeamMemberInSubscriptionTableHeader = memo((props: TeamMemberInSubs
 
     return (
         <tr className="bg-slate-100">
+            <th></th>
+
             <SortableTH sortKey="[name]" onClick={orderBy}>
                 이름
             </SortableTH>

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableRow.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableRow.tsx
@@ -29,13 +29,15 @@ interface TeamMemberInSubscriptionTableRowProps {
     seat: SubscriptionSeatDto;
     onClick?: (seat: SubscriptionSeatDto) => any;
     reload: () => any;
+    selected: boolean;
+    onSelect: (selected: boolean) => any;
 }
 
 export const TeamMemberInSubscriptionTableRow = memo((props: TeamMemberInSubscriptionTableRowProps) => {
     const orgId = useRecoilValue(orgIdParamState);
     const subscription = useRecoilValue(subscriptionSubjectAtom);
     const [isLoading, setIsLoading] = useState(false);
-    const {seat, onClick, reload} = props;
+    const {seat, onClick, reload, selected, onSelect} = props;
 
     const [seatDateValue, setSeatDateValue] = useState({
         startDate: seat.startAt || null,
@@ -86,6 +88,14 @@ export const TeamMemberInSubscriptionTableRow = memo((props: TeamMemberInSubscri
 
     return (
         <tr className="group">
+            <td className={`${hoverBgColor} ${loadingStyle}`}>
+                <input
+                    type="checkbox"
+                    checked={selected}
+                    onChange={(e) => onSelect && onSelect(e.target.checked)}
+                    className="w-4 h-4 focus:ring-0 cursor-pointer"
+                />
+            </td>
             {/* 이름 */}
             <td className={`${hoverBgColor} ${loadingStyle}`}>
                 <OpenButtonColumn href={showPagePath}>

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableRow.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableRow.tsx
@@ -18,7 +18,6 @@ import {
     UpdateSubscriptionSeatRequestDto,
 } from '^models/SubscriptionSeat/type';
 import {subscriptionApi} from '^models/Subscription/api';
-import {confirm2, confirmed} from '^components/util/dialog';
 import {yyyy_mm_dd} from '^utils/dateTime';
 import {debounce} from 'lodash';
 import {SelectColumn} from '^v3/share/table/columns/SelectColumn';
@@ -31,13 +30,14 @@ interface TeamMemberInSubscriptionTableRowProps {
     reload: () => any;
     selected: boolean;
     onSelect: (selected: boolean) => any;
+    onDelete: () => any;
 }
 
 export const TeamMemberInSubscriptionTableRow = memo((props: TeamMemberInSubscriptionTableRowProps) => {
     const orgId = useRecoilValue(orgIdParamState);
     const subscription = useRecoilValue(subscriptionSubjectAtom);
     const [isLoading, setIsLoading] = useState(false);
-    const {seat, onClick, reload, selected, onSelect} = props;
+    const {seat, onClick, reload, selected, onSelect, onDelete} = props;
 
     const [seatDateValue, setSeatDateValue] = useState({
         startDate: seat.startAt || null,
@@ -62,29 +62,6 @@ export const TeamMemberInSubscriptionTableRow = memo((props: TeamMemberInSubscri
             .catch(errorToast)
             .finally(() => setIsLoading(false));
     }, 500);
-
-    const onDelete = () => {
-        const deleteConfirm = () => {
-            return confirm2(
-                `구독 연결을 해제할까요?`,
-                <span>
-                    이 작업은 취소할 수 없습니다.
-                    <br />
-                    <b>이 멤버가 구독에서 제외</b>됩니다. <br />
-                    그래도 연결을 해제 하시겠어요?
-                </span>,
-                'warning',
-            );
-        };
-
-        confirmed(deleteConfirm())
-            .then(() => setIsLoading(true))
-            .then(() => subscriptionApi.seatsApi.destroy(orgId, subscription.id, seat.id))
-            .then(() => toast.success('삭제했습니다'))
-            .then(() => reload())
-            .catch(errorToast)
-            .finally(() => setIsLoading(false));
-    };
 
     return (
         <tr className="group">

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
@@ -1,4 +1,3 @@
-import {StatusCard} from '^clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionInfoTab/StatusCard';
 import {ListTable, ListTableContainer} from '^clients/private/_components/table/ListTable';
 import React, {memo, useEffect, useState} from 'react';
 import {useRecoilValue} from 'recoil';
@@ -35,11 +34,6 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
     const [selectedMembers, setSelectedMembers] = useState<number[]>([]);
 
     if (!orgId || !subscription) return <></>;
-
-    const onClose = () => {
-        setIsOpened(false);
-        onPageReload();
-    };
 
     const onPageReload = () => {
         reload();

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
@@ -31,6 +31,7 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
     const {refetch: refetchFinishTargetSeatCounter} = useFinishTargetSeatCounter(subscription);
     const {refetch: refetchQuitStatusSeatCount} = useQuitStatusSeatCounter(subscription);
 
+    const teamMembers = result.items.filter((item) => item.teamMember);
     const [selectedMembers, setSelectedMembers] = useState<number[]>([]);
 
     if (!orgId || !subscription) return <></>;
@@ -138,16 +139,16 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
                 }
             >
                 <ListTable
-                    items={result.items}
+                    items={teamMembers}
                     isLoading={false}
                     addBottomPadding={true}
                     Header={() => (
                         <TeamMemberInSubscriptionTableHeader
                             orderBy={orderBy}
-                            allSelected={selectedMembers.length > 0 && selectedMembers.length === result.items.length}
+                            allSelected={selectedMembers.length > 0 && selectedMembers.length === teamMembers.length}
                             onAllSelect={() =>
                                 setSelectedMembers((prev) =>
-                                    prev.length === result.items.length ? [] : result.items.map((item) => item.id),
+                                    prev.length === teamMembers.length ? [] : teamMembers.map((item) => item.id),
                                 )
                             }
                         />

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
@@ -15,7 +15,7 @@ import {useAssignedSeatCounter} from '^clients/private/orgs/subscriptions/OrgSub
 import {useFinishTargetSeatCounter} from '^clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/FinishTargetSeatCounter';
 import {usePaidSeatCounter} from '^clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/PaidSeatCounter';
 import {useQuitStatusSeatCounter} from '^clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/QuitStatusSeatCounter';
-import {Plus} from 'lucide-react';
+import {MinusCircle, Plus} from 'lucide-react';
 
 export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
     const orgId = useRecoilValue(orgIdParamState);
@@ -90,6 +90,21 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
                         &nbsp;멤버 연결하기
                     </button>
                 )}
+                TopMenu={
+                    selectedMembers.length > 0
+                        ? () => (
+                              <div className="flex items-stretch border border-gray-200 rounded-md shadow-sm">
+                                  <div className="text-sm py-1 px-2">{`${selectedMembers.length}명 선택됨`}</div>
+                                  <button
+                                      onClick={() => {}}
+                                      className="border-l border-gray-200 py-1 px-2 hover:bg-gray-100"
+                                  >
+                                      <MinusCircle className="size-4 text-red-500" />
+                                  </button>
+                              </div>
+                          )
+                        : undefined
+                }
             >
                 <ListTable
                     items={result.items}

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
@@ -141,7 +141,17 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
                     items={result.items}
                     isLoading={false}
                     addBottomPadding={true}
-                    Header={() => <TeamMemberInSubscriptionTableHeader orderBy={orderBy} />}
+                    Header={() => (
+                        <TeamMemberInSubscriptionTableHeader
+                            orderBy={orderBy}
+                            allSelected={selectedMembers.length > 0 && selectedMembers.length === result.items.length}
+                            onAllSelect={() =>
+                                setSelectedMembers((prev) =>
+                                    prev.length === result.items.length ? [] : result.items.map((item) => item.id),
+                                )
+                            }
+                        />
+                    )}
                     Row={({item}) => (
                         <TeamMemberInSubscriptionTableRow
                             seat={item}

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
@@ -2,6 +2,11 @@ import {StatusCard} from '^clients/private/orgs/subscriptions/OrgSubscriptionDet
 import {ListTable, ListTableContainer} from '^clients/private/_components/table/ListTable';
 import React, {memo, useEffect, useState} from 'react';
 import {useRecoilValue} from 'recoil';
+import {toast} from 'react-hot-toast';
+import {MinusCircle, Plus} from 'lucide-react';
+import {confirm2, confirmed} from '^components/util/dialog';
+import {ApiError, errorToast} from '^api/api';
+import {subscriptionApi} from '^models/Subscription/api';
 import {useCurrentSubscription} from '^clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/atom';
 import {orgIdParamState} from '^atoms/common';
 import {TeamMemberInSubscriptionTableRow} from '^clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/TeamMemberInSubscriptionTableRow';
@@ -15,7 +20,6 @@ import {useAssignedSeatCounter} from '^clients/private/orgs/subscriptions/OrgSub
 import {useFinishTargetSeatCounter} from '^clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/FinishTargetSeatCounter';
 import {usePaidSeatCounter} from '^clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/PaidSeatCounter';
 import {useQuitStatusSeatCounter} from '^clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/QuitStatusSeatCounter';
-import {MinusCircle, Plus} from 'lucide-react';
 
 export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
     const orgId = useRecoilValue(orgIdParamState);
@@ -58,6 +62,39 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
             });
     };
 
+    const onDeleteMembers = (targetMembers: number[]) => {
+        confirmed(
+            confirm2(
+                `구독 연결을 해제할까요?`,
+                <span>
+                    이 작업은 취소할 수 없습니다.
+                    <br />
+                    <b>선택한 멤버가 구독에서 제외</b>됩니다. <br />
+                    그래도 연결을 해제 하시겠어요?
+                </span>,
+                'warning',
+                {
+                    showLoaderOnConfirm: true,
+                    preConfirm: async () => {
+                        try {
+                            await Promise.all(
+                                targetMembers.map((id) => subscriptionApi.seatsApi.destroy(orgId, subscription.id, id)),
+                            );
+                            setSelectedMembers([]);
+                            toast.success('삭제했습니다');
+                            reload();
+                        } catch (e) {
+                            errorToast(e as ApiError);
+                        }
+                    },
+                    customClass: {
+                        loader: 'mx-auto',
+                    },
+                },
+            ),
+        ).catch(errorToast);
+    };
+
     useEffect(() => {
         orgId && onPageReload();
     }, [orgId]);
@@ -96,7 +133,7 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
                               <div className="flex items-stretch border border-gray-200 rounded-md shadow-sm">
                                   <div className="text-sm py-1 px-2">{`${selectedMembers.length}명 선택됨`}</div>
                                   <button
-                                      onClick={() => {}}
+                                      onClick={() => onDeleteMembers(selectedMembers)}
                                       className="border-l border-gray-200 py-1 px-2 hover:bg-gray-100"
                                   >
                                       <MinusCircle className="size-4 text-red-500" />
@@ -121,6 +158,7 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
                                     value ? [...prev, item.id] : prev.filter((v) => v !== item.id),
                                 )
                             }
+                            onDelete={() => onDeleteMembers([item.id])}
                         />
                     )}
                 />

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
@@ -28,6 +28,8 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
     const {refetch: refetchFinishTargetSeatCounter} = useFinishTargetSeatCounter(subscription);
     const {refetch: refetchQuitStatusSeatCount} = useQuitStatusSeatCounter(subscription);
 
+    const [selectedMembers, setSelectedMembers] = useState<number[]>([]);
+
     if (!orgId || !subscription) return <></>;
 
     const onClose = () => {
@@ -94,7 +96,18 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
                     isLoading={false}
                     addBottomPadding={true}
                     Header={() => <TeamMemberInSubscriptionTableHeader orderBy={orderBy} />}
-                    Row={({item}) => <TeamMemberInSubscriptionTableRow seat={item} reload={onPageReload} />}
+                    Row={({item}) => (
+                        <TeamMemberInSubscriptionTableRow
+                            seat={item}
+                            reload={onPageReload}
+                            selected={selectedMembers.includes(item.id)}
+                            onSelect={(value: boolean) =>
+                                setSelectedMembers((prev) =>
+                                    value ? [...prev, item.id] : prev.filter((v) => v !== item.id),
+                                )
+                            }
+                        />
+                    )}
                 />
             </ListTableContainer>
 

--- a/src/models/TeamMember/components/TeamMemberSelectItem.tsx
+++ b/src/models/TeamMember/components/TeamMemberSelectItem.tsx
@@ -22,8 +22,6 @@ export const TeamMemberSelectItem = memo((props: TeamMemberSelectItemProps) => {
             <div className="flex items-center">
                 <button className="relative">
                     <Check
-                        fontSize={16}
-                        strokeWidth={0.3}
                         className={isSelected ? `text-indigo-500` : 'text-transparent group-hover:text-indigo-200'}
                     />
                 </button>


### PR DESCRIPTION
PR에 포함된 변경사항을 간략하게 작성해 주세요.

 - 구독 상세 페이지 > 멤버 탭의 테이블에 멤버를 선택할 수 있는 체크박스 UI와, 선택된 멤버들을 제외할 수 있는 UI를 추가했어요.
    <img width="393" alt="SCR-20250320-kqia" src="https://github.com/user-attachments/assets/e3f1ca0f-f73c-4080-bd2e-43d3e32032df" />
 - 구독에서 멤버를 제외하는 confirm 창에 대한 로직과 UI를 수정했어요.
    <img width="536" alt="SCR-20250320-kthm" src="https://github.com/user-attachments/assets/e4cff507-f672-487b-b21a-2fcdfd5f5db2" />
    - 여러 멤버를 한 번에 제외할 수 있는 onDeleteMembers 함수를 생성하고, 개별 멤버를 제외하는 버튼에서도 해당 함수를 사용하도록 변경했어요.
    - 멤버를 제외할 때 로딩 UI가 confirm 창에 표시되도록(버튼이 Spinner로 바뀌어 표시됨) 변경했어요.
  - 멤버 연결하기 버튼을 클릭했을 때 표시되는 모달 창(`SlideUpAllSelectModal` 컴포넌트)에 멤버를 검색할 수 있는 UI를 추가했어요.
  - 그 외에 사용하지 않는 코드(unused import, props, console.log 등)들을 제거했어요.
  
  <!-- - 팀 멤버 필터링 기능 개선으로 구독 상세 테이블에 정확한 데이터 표시 -->

## Note

변경사항 외에 참고사항, 질문, 중점적으로 리뷰가 필요한 부분이 있다면 적어 주세요.

- 
