### PR TITLE
[Refactor] 구독 등록하기p-청구서 메일 다중 선택

### DIFF
--- a/src/clients/private/_modals/SlideUpSelectModal/index.tsx
+++ b/src/clients/private/_modals/SlideUpSelectModal/index.tsx
@@ -22,6 +22,7 @@ interface SlideUpSelectModalProps<T> {
     items?: T[];
     Row: (props: {item: T; onClick?: (selected: T) => any; isSelected?: boolean}) => JSX.Element;
     getId: (item: T) => number;
+    Button?: () => JSX.Element;
 
     /**
      * UI Text & Style Options
@@ -35,7 +36,7 @@ interface SlideUpSelectModalProps<T> {
 
 export const SlideUpSelectModal = <T,>(props: SlideUpSelectModalProps<T>) => {
     const {isOpened, onClose, onOpened: _onOpened, onClosed: _onClosed, onCreate, onSubmit: _onSubmit} = props;
-    const {isLoading = false, items = [], Row, getId} = props;
+    const {isLoading = false, items = [], Row, getId, Button} = props;
     const {titleCaption = '', title, ctaInactiveText = '', ctaActiveText = '', successMessage = '연결했어요.'} = props;
     const [selectedIds, setSelectedIds] = useState<number[]>([]);
 
@@ -94,6 +95,7 @@ export const SlideUpSelectModal = <T,>(props: SlideUpSelectModalProps<T>) => {
                             />
                         ))}
                     </LoadableBox>
+                    {Button && <Button />}
                 </div>
             </div>
 

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionConnectsPage/ContentFunnels/PrevNextButtons.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionConnectsPage/ContentFunnels/PrevNextButtons.tsx
@@ -4,12 +4,18 @@ import {useRecoilState, useRecoilValue, useResetRecoilState} from 'recoil';
 import {toast} from 'react-hot-toast';
 import {subscriptionApi} from '^models/Subscription/api';
 import {selectedTeamMembersAtom} from './inputs/TeamMemberSelect/atom';
-import {createSubscriptionFormData, currentStepAtom, finishedProductMapAtom} from './atom';
+import {
+    createSubscriptionForInvoiceAccountFormData,
+    createSubscriptionFormData,
+    currentStepAtom,
+    finishedProductMapAtom,
+} from './atom';
 import {Steps} from './steps';
 import {useCurrentConnectingProduct} from './useCurrentConnectingProduct';
 import {OrgMainPageRoute} from '^pages/orgs/[id]';
 import {useWorkspaceSubscriptionCount} from '^models/Subscription/hook';
 import {useOrgIdParam} from '^atoms/common';
+import {invoiceAccountApi} from '^models/InvoiceAccount/api';
 
 export const PrevNextButtons = memo(function PrevNextButtons() {
     const router = useRouter();
@@ -18,31 +24,46 @@ export const PrevNextButtons = memo(function PrevNextButtons() {
     const clearFormData = useResetRecoilState(createSubscriptionFormData);
     const [teamMembers, setTeamMembers] = useRecoilState(selectedTeamMembersAtom);
     const [currentStep, setStep] = useRecoilState(currentStepAtom);
+    const [invoiceAccountData, setInvoiceAccountData] = useRecoilState(createSubscriptionForInvoiceAccountFormData);
     const {currentConnectingProduct, finishProduct} = useCurrentConnectingProduct();
     const resetFinishedProductMap = useResetRecoilState(finishedProductMapAtom);
     const {refetch} = useWorkspaceSubscriptionCount(orgId);
-
-    //currentConnectingProduct?.id === product.id
 
     const prev = (i: number) => i - 1;
     const next = (i: number) => i + 1;
 
     const createSubscription = () => {
-        subscriptionApi.create(formData).then((res) => {
-            const subscription = res.data;
-            toast.success(`${currentConnectingProduct?.nameKo} 구독을 등록했어요.`);
-            setTeamMembers([]);
-            clearFormData();
-            const nextProduct = finishProduct(subscription.productId);
-
-            if (nextProduct) {
-                setStep(Steps.IsFreeTier);
-            } else {
-                return router.push(OrgMainPageRoute.path(subscription.organizationId)).then(() => {
-                    resetFinishedProductMap();
+        subscriptionApi
+            .create(formData)
+            .then((res) => {
+                const subscription = res.data;
+                Promise.allSettled(
+                    invoiceAccountData.invoiceAccountIds.map((invoiceAccountId) =>
+                        invoiceAccountApi.subscriptionsApi.create(invoiceAccountId, subscription.id),
+                    ),
+                ).then(() => subscription);
+                return subscription;
+            })
+            .then((subscription) => {
+                toast.success(`${currentConnectingProduct?.nameKo} 구독을 등록했어요.`);
+                setInvoiceAccountData({
+                    invoiceAccounts: [],
+                    invoiceAccountIds: [],
                 });
-            }
-        });
+                setTeamMembers([]);
+                clearFormData();
+                const nextProduct = finishProduct(subscription.productId);
+                if (nextProduct) {
+                    setStep(Steps.IsFreeTier);
+                } else {
+                    return router.push(OrgMainPageRoute.path(subscription.organizationId)).then(() => {
+                        resetFinishedProductMap();
+                    });
+                }
+            })
+            .catch((error) => {
+                console.error('구독 생성 실패', error);
+            });
     };
 
     switch (currentStep) {
@@ -96,7 +117,7 @@ export const PrevNextButtons = memo(function PrevNextButtons() {
                     onPrev={() => setStep(prev)}
                     onNext={() => setStep(next)}
                     isValid={true}
-                    nextButtonText={formData.invoiceAccountId ? undefined : '건너뛰기'}
+                    nextButtonText={invoiceAccountData.invoiceAccountIds ? undefined : '건너뛰기'}
                 />
             );
         case Steps.TeamMembers:

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionConnectsPage/ContentFunnels/atom.ts
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionConnectsPage/ContentFunnels/atom.ts
@@ -3,6 +3,8 @@ import {BillingCycleOptions} from '^models/Subscription/types/BillingCycleOption
 import {CreateSubscriptionRequestDto} from '^models/Subscription/types';
 import {localStorageAtoms} from '^atoms/localStorage.atom';
 import {ProductDto} from '^models/Product/type';
+import {AccountDto} from '^models/Account/types';
+import {InvoiceAccountDto} from '^models/InvoiceAccount/type';
 
 export const currentStepAtom = atom({
     key: 'currentStepAtom',
@@ -19,6 +21,18 @@ export const recurringIsFreeAtom = atom({
 export const createSubscriptionFormData = atom<CreateSubscriptionRequestDto>({
     key: 'createSubscriptionFormData',
     default: {} as CreateSubscriptionRequestDto,
+});
+
+// 구독 등록 시 청구서 메일 계정 폼
+export const createSubscriptionForInvoiceAccountFormData = atom<{
+    invoiceAccounts: InvoiceAccountDto[];
+    invoiceAccountIds: number[];
+}>({
+    key: 'createSubscriptionForInvoiceAccountFormData',
+    default: {
+        invoiceAccounts: [],
+        invoiceAccountIds: [],
+    },
 });
 
 // 구독 주기 (no use)

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionConnectsPage/ContentFunnels/inputs/InvoiceAccountSelect/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionConnectsPage/ContentFunnels/inputs/InvoiceAccountSelect/index.tsx
@@ -112,7 +112,7 @@ export const InvoiceAccountSelect = memo(function InvoiceAccountSelect(props: In
                     {selectedInvoiceAccountIds?.length > 0 && (
                         <ul className="w-full flex flex-col gap-4 px-1">
                             {selectedInvoiceAccounts.map((invoiceAccount) => (
-                                <li className="w-full flex items-center justify-between">
+                                <li key={invoiceAccount.id} className="w-full flex items-center justify-between">
                                     <InvoiceAccountProfile invoiceAccount={invoiceAccount} />
                                     <CircleX
                                         onClick={() => onDelete(invoiceAccount)}

--- a/src/components/pages/v3/share/table/columns/SelectColumn/DetachableOptionItem/index.tsx
+++ b/src/components/pages/v3/share/table/columns/SelectColumn/DetachableOptionItem/index.tsx
@@ -28,7 +28,7 @@ export const DetachableOptionItem = <T,>(props: DetachableOptionItemProps<T>) =>
                             onClick={() => detachRequest(option)}
                         >
                             <button className="btn btn-2xs btn-square shadow rounded-[4px] !bg-white border-gray-300">
-                                <Minus fontSize={18} className="text-gray-400" strokeWidth={10} />
+                                <Minus fontSize={18} className="text-gray-400" strokeWidth={2} />
                             </button>
                         </div>
                     </Tippy>

--- a/src/models/CreditCard/components/CreditCardSelectItem.tsx
+++ b/src/models/CreditCard/components/CreditCardSelectItem.tsx
@@ -22,9 +22,10 @@ export const CreditCardSelectItem = memo((props: CreditCardSelectItemProps) => {
             <div className="flex items-center">
                 <button className="relative">
                     <Check
-                        fontSize={16}
-                        strokeWidth={0.3}
-                        className={isSelected ? `text-indigo-500` : 'text-transparent group-hover:text-indigo-200'}
+                        strokeWidth={3}
+                        className={`text-20 ${
+                            isSelected ? `text-indigo-500` : 'text-transparent group-hover:text-indigo-200'
+                        }`}
                     />
                 </button>
             </div>

--- a/src/models/InvoiceAccount/components/InvoiceAccountSelectItem.tsx
+++ b/src/models/InvoiceAccount/components/InvoiceAccountSelectItem.tsx
@@ -22,9 +22,10 @@ export const InvoiceAccountSelectItem = memo((props: InvoiceAccountSelectItemPro
             <div className="flex items-center">
                 <button className="relative">
                     <Check
-                        fontSize={16}
-                        strokeWidth={0.3}
-                        className={isSelected ? `text-indigo-500` : 'text-transparent group-hover:text-indigo-200'}
+                        strokeWidth={3}
+                        className={`text-20 ${
+                            isSelected ? `text-indigo-500` : 'text-transparent group-hover:text-indigo-200'
+                        }`}
                     />
                 </button>
             </div>

--- a/src/models/TeamMember/components/TeamMemberSelectItem.tsx
+++ b/src/models/TeamMember/components/TeamMemberSelectItem.tsx
@@ -22,7 +22,10 @@ export const TeamMemberSelectItem = memo((props: TeamMemberSelectItemProps) => {
             <div className="flex items-center">
                 <button className="relative">
                     <Check
-                        className={isSelected ? `text-indigo-500` : 'text-transparent group-hover:text-indigo-200'}
+                        strokeWidth={3}
+                        className={`text-20 ${
+                            isSelected ? `text-indigo-500` : 'text-transparent group-hover:text-indigo-200'
+                        }`}
                     />
                 </button>
             </div>


### PR DESCRIPTION
## Description

PR에 포함된 변경사항을 간략하게 작성해 주세요.

|기존|변경|
|---|---|
|<img width="680" alt="image" src="https://github.com/user-attachments/assets/71e26a1d-b935-4377-9b89-e788c19bf413" />|<img width="697" alt="image" src="https://github.com/user-attachments/assets/6c33b598-b3ad-410c-a1c5-02b0dddac2de" />|

1. 아이콘이 일부 깨지는 부분이 확인되어 아이콘 크기, 두께 일부 아이콘 자체 수정
2. 청구서 메일 계정 폼을 저장하기 위한 atom 추가 
3. SlideUpSelectModal 컴포넌트에 버튼 컴포넌트를 받을 수 있도록 추가
→ 기존 SlideUpSelectModal은 멀티 셀렉트로 선택한 값만 추가할 수 있음
→ 구독 등록하기에서 청구서 메일 추가가 가지고 있던모달의 경우 새로운 청구서 메일도 추가할 수 있어야함(수동/자동)
4. InvoiceAcountSelect 컴포넌트에서 invoiceAccout를 단일 값만 받아 처리 → 배열로 받을 수 있도록 함수들을 수정 및 추가
5. PrevNextButton 컴포넌트에서 구독을 먼저 생성 > 생성된 구독과 청구서 수신 메일을 연결할 수 있도록 api 추가 


## Note

변경사항 외에 참고사항, 질문, 중점적으로 리뷰가 필요한 부분이 있다면 적어 주세요.

- 
