### PR TITLE
검색 엔진에서 products 페이지가 색인되지 않도록 변경

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
+Disallow: /products/
 Allow: /
 Sitemap: https://scordi.io/sitemap.xml


### PR DESCRIPTION
## Description

- robots.txt 파일에 `Disallow: /products/` 구문을 추가해서 해당 경로가 검색엔진에 색인되지 않도록 처리해요.

## Note

- 
