### PR TITLE
[구독 > 구독리스트 > 구독상세 > 멤버탭] 여러 멤버의 구독 연결을 해제할 때 발생하던 에러를 해결해요.

### DIFF
--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/index.tsx
@@ -72,9 +72,7 @@ export const SubscriptionMemberTab = memo(function SubscriptionMemberTab() {
                     showLoaderOnConfirm: true,
                     preConfirm: async () => {
                         try {
-                            await Promise.all(
-                                targetMembers.map((id) => subscriptionApi.seatsApi.destroy(orgId, subscription.id, id)),
-                            );
+                            await subscriptionApi.seatsApi.destroyAll(orgId, subscription.id, targetMembers);
                             setSelectedMembers([]);
                             toast.success('계정을 회수했어요.');
                             reload();

--- a/src/models/Subscription/api/index.ts
+++ b/src/models/Subscription/api/index.ts
@@ -112,5 +112,11 @@ export const subscriptionApi = {
             const url = `${controllerPath}/seats/${id}`;
             return api.delete(url).then(oneDtoOf(SubscriptionSeatDto));
         },
+
+        destroyAll(orgId: number, subscriptionId: number, ids: number[]) {
+            const controllerPath = `/organization/${orgId}/subscriptions/${subscriptionId}`;
+            const url = `${controllerPath}/seats`;
+            return api.delete(url, {params: {ids}});
+        },
     },
 };


### PR DESCRIPTION
## Description

- `구독 > 구독리스트 > 구독상세 > 멤버탭 UI`에서 여러 멤버의 구독 연결을 해제할 때, 백엔드 서버의 Deadlock 이슈로 `500 Internal server error`가 발생하던 현상을 수정해요.
  - 서버에서 `destroyAll` API를 생성하고, 클라이언트에서 해당 API를 사용하는 것으로 수정했어요.

## Note

- 
