### PR TITLE
Sentry를 staging 환경에서도 활성화해요.

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -7,6 +7,7 @@ import {deployEnv} from '^config/environments';
 
 if (deployEnv === 'production' || deployEnv === 'staging') {
     Sentry.init({
+        environment: deployEnv,
         dsn: 'https://92e1cc608c794d3482a377ed860d7010@o1068306.ingest.sentry.io/4505594818002944',
 
         // Adjust this value in production, or use tracesSampler for greater control

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,8 +3,9 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
+import {deployEnv} from '^config/environments';
 
-if (process.env.NEXT_PUBLIC_APP_ENV === 'production') {
+if (deployEnv === 'production' || deployEnv === 'staging') {
     Sentry.init({
         dsn: 'https://92e1cc608c794d3482a377ed860d7010@o1068306.ingest.sentry.io/4505594818002944',
 
@@ -13,20 +14,5 @@ if (process.env.NEXT_PUBLIC_APP_ENV === 'production') {
 
         // Setting this option to true will print useful information to the console while you're setting up Sentry.
         debug: false,
-
-        replaysOnErrorSampleRate: 1.0,
-
-        // This sets the sample rate to be 10%. You may want this to be 100% while
-        // in development and sample at a lower rate in production
-        replaysSessionSampleRate: 0.1,
-
-        // You can remove this option if you're not planning to use the Sentry Session Replay feature:
-        integrations: [
-            new Sentry.Replay({
-                // Additional Replay configuration goes in here, for example:
-                maskAllText: true,
-                blockAllMedia: true,
-            }),
-        ],
     });
 }

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -8,6 +8,7 @@ import {deployEnv} from '^config/environments';
 
 if (deployEnv === 'production' || deployEnv === 'staging') {
     Sentry.init({
+        environment: deployEnv,
         dsn: 'https://92e1cc608c794d3482a377ed860d7010@o1068306.ingest.sentry.io/4505594818002944',
 
         // Adjust this value in production, or use tracesSampler for greater control

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,8 +4,9 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
+import {deployEnv} from '^config/environments';
 
-if (process.env.NEXT_PUBLIC_APP_ENV === 'production') {
+if (deployEnv === 'production' || deployEnv === 'staging') {
     Sentry.init({
         dsn: 'https://92e1cc608c794d3482a377ed860d7010@o1068306.ingest.sentry.io/4505594818002944',
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -7,6 +7,7 @@ import {deployEnv} from '^config/environments';
 
 if (deployEnv === 'production' || deployEnv === 'staging') {
     Sentry.init({
+        environment: deployEnv,
         dsn: 'https://92e1cc608c794d3482a377ed860d7010@o1068306.ingest.sentry.io/4505594818002944',
 
         // Adjust this value in production, or use tracesSampler for greater control

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,8 +3,9 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
+import {deployEnv} from '^config/environments';
 
-if (process.env.NEXT_PUBLIC_APP_ENV === 'production') {
+if (deployEnv === 'production' || deployEnv === 'staging') {
     Sentry.init({
         dsn: 'https://92e1cc608c794d3482a377ed860d7010@o1068306.ingest.sentry.io/4505594818002944',
 


### PR DESCRIPTION
## Description

- Sentry를 staging 환경에서 활성화하고, `environment` 별로 분기 처리해요.
- 기존에 `sentry.client.config.ts` 에서 활성화 되어 있던 세션 리플레이 관련 설정들을 제거해요.

## Note

- 
