### PR TITLE
일부 아이콘 모양 및 크기를 변경해요.

### DIFF
--- a/src/clients/private/_layouts/MainLayout/OrgTopBar/index.tsx
+++ b/src/clients/private/_layouts/MainLayout/OrgTopBar/index.tsx
@@ -68,7 +68,7 @@ export const OrgTopBar = memo(() => {
                 </div>
 
                 <div className="text-gray-400 transition-all hover:text-scordi-500 cursor-pointer">
-                    <Bell size={20} className="" />
+                    <Bell className="size-5" />
                 </div>
 
                 <div>

--- a/src/clients/private/_layouts/MainLayout/TopNavBar/index.tsx
+++ b/src/clients/private/_layouts/MainLayout/TopNavBar/index.tsx
@@ -16,7 +16,7 @@ import {OrgInvoiceAccountListPageRoute} from '^pages/orgs/[id]/invoiceAccounts';
 import {OrgSettingsInformationPageRoute} from '^pages/orgs/[id]/settings';
 import {OrgBillingHistoryStatusPageRoute} from '^pages/orgs/[id]/billingHistories/status';
 import {MembershipDto, MembershipLevel} from '^models/Membership/types';
-import {BarChart4, CreditCard, LayoutDashboard, Receipt, User, Users} from 'lucide-react';
+import {BarChart4, CreditCard, LayoutDashboard, Mail, User, Users} from 'lucide-react';
 
 interface TopNavBarProps {
     //
@@ -42,7 +42,7 @@ const getTopNavStructure = (props: {currentUserMembership?: MembershipDto}) => [
         name: '자산',
         items: [
             {name: '결제수단', Icon: CreditCard, routeProps: OrgCreditCardListPageRoute},
-            {name: '청구서 메일', Icon: Receipt, routeProps: OrgInvoiceAccountListPageRoute},
+            {name: '청구서 메일', Icon: Mail, routeProps: OrgInvoiceAccountListPageRoute},
         ],
     },
     {

--- a/src/clients/private/_layouts/_shared/ListPageMainDropdown/MethodOption.tsx
+++ b/src/clients/private/_layouts/_shared/ListPageMainDropdown/MethodOption.tsx
@@ -18,9 +18,7 @@ export const MethodOption = memo((props: Props) => {
                 onClick={onClick}
                 className="py-2 px-4 group-hover:text-scordi group-hover:bg-scordi-light-50 transition-all flex items-center gap-3 cursor-pointer"
             >
-                <div>
-                    <Icon fontSize={20} />
-                </div>
+                <Icon />
 
                 <div className="flex-auto">
                     <p className="text-13">{title}</p>

--- a/src/clients/private/_modals/credit-cards/CardCreateMethodModal.tsx
+++ b/src/clients/private/_modals/credit-cards/CardCreateMethodModal.tsx
@@ -63,9 +63,7 @@ export const CardCreateMethodOption = (props: Props) => {
             className="flex items-center -mx-3 px-3 py-3 rounded-box cursor-pointer group hover:bg-scordi-50 transition-all"
             onClick={onClick}
         >
-            <div className="">
-                <Icon size={24} />
-            </div>
+            <Icon />
 
             <div className="flex-auto px-3">
                 <p className="text-14">{title}</p>

--- a/src/clients/private/_modals/invoice-accounts/InvoiceAccountCreateMethodModal.tsx
+++ b/src/clients/private/_modals/invoice-accounts/InvoiceAccountCreateMethodModal.tsx
@@ -68,9 +68,7 @@ export const CreateMethodOption = (props: Props) => {
             className="flex items-center -mx-3 px-3 py-3 rounded-box cursor-pointer group hover:bg-scordi-50 transition-all"
             onClick={onClick}
         >
-            <div className="">
-                <Icon size={24} />
-            </div>
+            <Icon />
 
             <div className="flex-auto px-3">
                 <p className="text-14">{title}</p>

--- a/src/clients/private/orgs/assets/invoice-accounts/OrgInvoiceAccountListPage/AddInvoiceAccountDropdown.tsx
+++ b/src/clients/private/orgs/assets/invoice-accounts/OrgInvoiceAccountListPage/AddInvoiceAccountDropdown.tsx
@@ -85,9 +85,7 @@ const CreateMethodOption = memo((props: Props) => {
                 onClick={onClick}
                 className="py-2 px-4 group-hover:text-scordi group-hover:bg-scordi-light-50 transition-all flex items-center gap-3 cursor-pointer"
             >
-                <div>
-                    <Icon fontSize={20} />
-                </div>
+                <Icon />
 
                 <div className="flex-auto">
                     <p className="text-13">{title}</p>

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionInfoTab/StatusCard.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionInfoTab/StatusCard.tsx
@@ -15,7 +15,7 @@ export const StatusCard = memo((props: StatusCardProps) => {
                 <div className="text-gray-600">{title}</div>
                 <div className="text-2xl font-medium max-w-[150px]">{titleValue}</div>
             </div>
-            <div className={` rounded-full p-2 ${iconColor} w-16 h-16`}>{icon}</div>
+            <div className={`size-16 rounded-full flex items-center justify-center ${iconColor}`}>{icon}</div>
         </div>
     );
 });

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionInfoTab/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionInfoTab/index.tsx
@@ -27,7 +27,7 @@ export const SubscriptionInfoTab = memo(function SubscriptionInfoTab() {
                 <StatusCard
                     title={'구독상태'}
                     titleValue={subscription?.isFreeTier ? '무료' : '유료'}
-                    icon={<Folder size={20} className="h-full w-full p-[6px] text-white" />}
+                    icon={<Folder className="size-6 text-white" />}
                     iconColor={'bg-purple-400'}
                 />
                 <StatusCard
@@ -35,19 +35,19 @@ export const SubscriptionInfoTab = memo(function SubscriptionInfoTab() {
                     titleValue={`${subscription?.currentBillingAmount?.symbol} ${roundNumber(
                         subscription.nextBillingAmount,
                     ).toLocaleString()}`}
-                    icon={<Banknote size={20} className="h-full w-full p-[6px] text-white" />}
+                    icon={<Banknote className="size-6 text-white" />}
                     iconColor={'bg-orange-400'}
                 />
                 <StatusCard
                     title={'다음 결제 예정일'}
                     titleValue={subscription?.nextBillingDate || '-'}
-                    icon={<Calendar size={20} className="h-full w-full p-[6px] text-white" />}
+                    icon={<Calendar className="size-6 text-white" />}
                     iconColor={'bg-pink-400'}
                 />
                 <StatusCard
                     title={'결제수단'}
                     titleValue={paymentMethodText}
-                    icon={<CreditCard size={20} className="h-full w-full p-[6px] text-white" />}
+                    icon={<CreditCard className="size-6 text-white" />}
                     iconColor={'bg-blue-400'}
                 />
             </div>

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/AssignedSeatCounter.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/AssignedSeatCounter.tsx
@@ -20,7 +20,7 @@ export const AssignedSeatCounter = memo(() => {
         <StatusCard
             title={'현재 할당된 계정'}
             titleValue={count.toLocaleString()}
-            icon={<User size={20} className="h-full w-full p-[6px] text-white" />}
+            icon={<User className="size-6 text-white" />}
             iconColor={'bg-purple-400'}
         />
     );

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/FinishTargetSeatCounter.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/FinishTargetSeatCounter.tsx
@@ -17,7 +17,7 @@ export const FinishTargetSeatCounter = memo(() => {
         <StatusCard
             title="이번달 회수(예정) 계정"
             titleValue={count.toLocaleString()}
-            icon={<UserMinus size={20} className="h-full w-full p-[6px] text-white" />}
+            icon={<UserMinus className="size-6 text-white" />}
             iconColor="bg-pink-400"
         />
     );

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/PaidSeatCounter.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/PaidSeatCounter.tsx
@@ -19,7 +19,7 @@ export const PaidSeatCounter = memo(() => {
         <StatusCard
             title="구매한 계정"
             titleValue={count.toLocaleString()}
-            icon={<UserPlus size={20} className="h-full w-full p-[6px] text-white" />}
+            icon={<UserPlus className="size-6 text-white" />}
             iconColor="bg-orange-400"
         />
     );

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/QuitStatusSeatCounter.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionDetailPage/SubscriptionMemberTab/SubscriptionSeatStatusSection/QuitStatusSeatCounter.tsx
@@ -20,7 +20,7 @@ export const QuitStatusSeatCounter = memo(() => {
         <StatusCard
             title="해지 완료된 계정"
             titleValue={count.toLocaleString()}
-            icon={<UserX size={20} className="h-full w-full p-[6px] text-white" />}
+            icon={<UserX className="size-6 text-white" />}
             iconColor="bg-blue-400"
         />
     );


### PR DESCRIPTION
## Description

- [슬랙에서 규리님이 요청한 아이콘 변경 건](https://01republic.slack.com/archives/C03SV31FC90/p1742885020837449?thread_ts=1742884995.752779&cid=C03SV31FC90)에 대응하는 PR이에요.
  - 상단 메뉴에서 알림(종) 아이콘 사이즈를 줄여요.
  - `자산 > 청구서메일 드롭다운`에 있는 영수증 아이콘을 다른 UI와 동일하게 메일 아이콘으로 변경해요.
  - 구독 상세 페이지에서 정보 탭과 멤버 탭의 요약 패널 아이콘들의 사이즈를 줄여요.
  - `결제내역 불러오기`, `청구서 내역 불러오기`, `직접 추가하기` 등의 모달 메뉴 UI에 사용되는 아이콘들의 사이즈를 줄여요.
  

## Note

- 
