### PR TITLE
Style/슬라이드업 모달 스타일 변경

### DIFF
--- a/src/clients/private/_modals/SlideUpAllSelectModal/index.tsx
+++ b/src/clients/private/_modals/SlideUpAllSelectModal/index.tsx
@@ -95,13 +95,14 @@ export const SlideUpAllSelectModal = <T,>(props: SlideUpAllSelectModalProps<T>) 
                 {titleCaption && <p className="text-12 text-scordi">{titleCaption}</p>}
                 <div className="w-full flex items-center justify-between">
                     <h3 className="text-18">{title}</h3>
-
-                    {items.length > 0 && (
-                        <button className="btn-white btn-sm" onClick={handleSelectAll}>
+                </div>
+                {items.length > 0 && (
+                    <div className="w-full flex justify-end">
+                        <button className="link link-primary no-underline text-14" onClick={handleSelectAll}>
                             {isAllSelect ? '선택취소' : '전체선택'}
                         </button>
-                    )}
-                </div>
+                    </div>
+                )}
             </div>
 
             <div className="relative w-[calc(100%-3rem)] mx-6 mt-6">

--- a/src/clients/private/_modals/SlideUpAllSelectModal/index.tsx
+++ b/src/clients/private/_modals/SlideUpAllSelectModal/index.tsx
@@ -84,8 +84,11 @@ export const SlideUpAllSelectModal = <T,>(props: SlideUpAllSelectModalProps<T>) 
     return (
         <SlideUpModal open={isOpened} onClose={onClose} size="md" modalClassName="rounded-none sm:rounded-t-box p-0">
             <div className="flex items-center">
-                <div className="p-6 text-gray-400 hover:text-black transition-all cursor-pointer" onClick={onClose}>
-                    <ChevronLeft fontSize={16} />
+                <div
+                    className="px-4 pt-5 pb-4 text-gray-400 hover:text-black transition-all cursor-pointer"
+                    onClick={onClose}
+                >
+                    <ChevronLeft fontSize={24} />
                 </div>
             </div>
             <div className="px-6 bg-white flex flex-col items-start justify-start">

--- a/src/clients/private/_modals/SlideUpSelectModal/index.tsx
+++ b/src/clients/private/_modals/SlideUpSelectModal/index.tsx
@@ -98,11 +98,11 @@ export const SlideUpSelectModal = <T,>(props: SlideUpSelectModalProps<T>) => {
                             />
                         ))}
                     </LoadableBox>
-                    {Button && <Button />}
                 </div>
             </div>
 
-            <div className="px-6 pb-4">
+            <div className="flex flex-col gap-2 px-6 pb-4">
+                {Button && <Button />}
                 {!selectedIds.length ? (
                     <button type="button" className="btn btn-scordi btn-block btn-disabled2">
                         {ctaInactiveText || '항목을 선택해주세요'}

--- a/src/clients/private/_modals/SlideUpSelectModal/index.tsx
+++ b/src/clients/private/_modals/SlideUpSelectModal/index.tsx
@@ -70,8 +70,11 @@ export const SlideUpSelectModal = <T,>(props: SlideUpSelectModalProps<T>) => {
     return (
         <SlideUpModal open={isOpened} onClose={onClose} size="md" modalClassName="rounded-none sm:rounded-t-box p-0">
             <div className="flex items-center">
-                <div className="p-6 text-gray-400 hover:text-black transition-all cursor-pointer" onClick={onClose}>
-                    <ChevronLeft fontSize={16} />
+                <div
+                    className="px-4 pt-5 pb-4 text-gray-400 hover:text-black transition-all cursor-pointer"
+                    onClick={onClose}
+                >
+                    <ChevronLeft fontSize={24} />
                 </div>
             </div>
             <div className="px-6 bg-white flex items-center justify-between">

--- a/src/clients/private/orgs/subscriptions/OrgSubscriptionConnectsPage/ContentFunnels/inputs/InvoiceAccountSelect/index.tsx
+++ b/src/clients/private/orgs/subscriptions/OrgSubscriptionConnectsPage/ContentFunnels/inputs/InvoiceAccountSelect/index.tsx
@@ -89,12 +89,13 @@ export const InvoiceAccountSelect = memo(function InvoiceAccountSelect(props: In
 
     const CreateInvoiceAccountButton = () => {
         return (
-            <div
+            <button
+                type="button"
                 onClick={() => setIsCreateMethodModalOpen(true)}
-                className="btn btn-white w-full flex items-center justify-center py-1 mt-1"
+                className="btn btn-white btn-block flex items-center justify-center"
             >
-                <p>청구서 메일 추가</p>
-            </div>
+                청구서 메일 추가
+            </button>
         );
     };
 


### PR DESCRIPTION
## Description

<!-- PR에 포함된 변경사항을 간략하게 작성해 주세요. -->

-  전체선택 버튼이 존재하는 슬라이드업 모달에 위차하는 전제 선택 버튼의 스타일이 변경되었어요 
1. btn → link 스타일로 변경
2. title과 동일 선상에 위치 → 모달 head 영역 가장 하단에 위치
- 다중 선택 슽라이드업 모달에 props로 받는 버튼의 위치가 가장 하단에 고정적으로 위치하도록 변경되었어요.
- 모달들에 뒤로가기 버튼 아이콘의 크기가 수정되었어요 16 → 24
- 구독 등록하기 > 이메일 등록p/ 슬라이드업 모달 props로 전달하는 버튼 스타일이 수정되었어요. w-full → btn-block

## Note

<!-- 변경사항 외에 참고사항, 질문, 중점적으로 리뷰가 필요한 부분이 있다면 적어 주세요. -->

- 
