### PR TITLE
Babel 대신 SWC를 사용해요

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": [
-    ["@babel/plugin-proposal-decorators", {
-      "legacy" : true
-    }]
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "deploy:production": "bash tasks/deploy.production.sh"
   },
   "dependencies": {
-    "@babel/plugin-proposal-decorators": "^7.22.15",
     "@googleapis/docs": "^2.0.1",
     "@headlessui/react": "^1.6.6",
     "@measured-im/browser": "^1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ importers:
 
   .:
     dependencies:
-      '@babel/plugin-proposal-decorators':
-        specifier: ^7.22.15
-        version: 7.25.9(@babel/core@7.26.0)
       '@googleapis/docs':
         specifier: ^2.0.1
         version: 2.0.5
@@ -484,20 +481,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/plugin-proposal-decorators@7.25.9':
-    resolution: {integrity: sha512-smkNLL/O1ezy9Nhy4CNosc4Va+1wo5w4gzSZeLe6y6dM4mmHfYOCPolXQPHQxonZCF+ZyebxN9vqOolkYrSn5g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-decorators@7.25.9':
-    resolution: {integrity: sha512-ryzI0McXUPJnRCvMo4lumIKZUzhYUO/ScI+Mz4YVaTLt04DHNSjEUjKVvbzQjZFLuod/cYEc07mJWhzl6v4DPg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4697,23 +4682,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.26.0)':
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.0)
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-
-  '@babel/plugin-syntax-decorators@7.25.9(@babel/core@7.26.0)':
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.26.0)':
     dependencies:
@@ -7172,8 +7143,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.19.0)(typescript@4.9.5)
       eslint: 8.19.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint@8.19.0))(eslint@8.19.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint@8.19.0))(eslint@8.19.0))(eslint@8.19.0)
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0)(eslint@8.19.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@8.19.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.19.0)
       eslint-plugin-react: 7.37.2(eslint@8.19.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.19.0)
@@ -7195,11 +7166,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint@8.19.0))(eslint@8.19.0):
+  eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.19.0):
     dependencies:
       debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.19.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint@8.19.0))(eslint@8.19.0))(eslint@8.19.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@8.19.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.8
@@ -7207,18 +7178,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint@8.19.0))(eslint@8.19.0))(eslint@8.19.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1)(eslint@8.19.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.19.0)(typescript@4.9.5)
       eslint: 8.19.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint@8.19.0))(eslint@8.19.0)
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0)(eslint@8.19.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint@8.19.0))(eslint@8.19.0))(eslint@8.19.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@8.19.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -7229,7 +7200,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.19.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint@8.19.0))(eslint@8.19.0))(eslint@8.19.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.19.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1)(eslint@8.19.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Description

- 기존에 `.babelrc` 파일의 존재로 인해 SWC가 비활성화 되어 있었는데, SWC가 Babel과 거의 완벽하게 호환되기 때문에 이제는 속도가 훨씬 빠른 SWC를 사용하면 좋을 것 같아요. 기존에 `.babelrc`에 설정되어 있던 데코레이터 부분도 문제없이 돌아가요.

## Note

<!-- 변경사항 외에 참고사항, 질문, 중점적으로 리뷰가 필요한 부분이 있다면 적어 주세요. -->

- 그냥 지나가다가 눈에 띄어서 수정해 보아요.
- ref) https://nextjs.org/docs/messages/swc-disabled
