### PR TITLE
Feat/팀상세p/구독탭 구독클릭 시 모달

### DIFF
--- a/src/clients/private/_components/dropdown-select/SubscriptionSelect.tsx
+++ b/src/clients/private/_components/dropdown-select/SubscriptionSelect.tsx
@@ -46,9 +46,9 @@ export const SubscriptionSelect = memo((props: SubscriptionSelectProps) => {
                     <SubscriptionProfile
                         subscription={subscriptionToShow}
                         className="gap-2"
-                        isAlias={false}
                         width={20}
                         height={20}
+                        isAlias={true}
                     />
                 ) : (
                     <span className="text-gray-500">구독 선택</span>
@@ -84,7 +84,6 @@ export const SubscriptionSelect = memo((props: SubscriptionSelectProps) => {
                                         <SubscriptionProfile
                                             subscription={subscription}
                                             className="gap-2"
-                                            isAlias={false}
                                             width={20}
                                             height={20}
                                         />

--- a/src/clients/private/_components/rest-pages/ShowPage/MoreDropdown/MoreDropdownMenuItem.tsx
+++ b/src/clients/private/_components/rest-pages/ShowPage/MoreDropdown/MoreDropdownMenuItem.tsx
@@ -18,7 +18,10 @@ export const MoreDropdownMenuItem = memo((props: MoreDropdownMenuItemProps) => {
         <div className="group">
             <div
                 tabIndex={0}
-                onClick={onClick}
+                onClick={(e) => {
+                    e.preventDefault();
+                    onClick();
+                }}
                 className={`cursor-pointer ${sizeClass(size)} ${themeClass(theme)} ${className}`}
             >
                 {children}

--- a/src/clients/private/orgs/home/OrgDashboardPage/MonthlyTotalExpenseSection/ExpenseStatusTabContent.tsx
+++ b/src/clients/private/orgs/home/OrgDashboardPage/MonthlyTotalExpenseSection/ExpenseStatusTabContent.tsx
@@ -87,7 +87,7 @@ export const ExpenseStatusTabContent = (props: ExpenseSubscriptionProps) => {
                                     height={20}
                                     className="gap-3"
                                     textClassName="text-14 font-base font-normal"
-                                    isAlias={false}
+                                    isAlias={true}
                                 />
                                 <p>{currencyFormat(roundNumber(spend.amount))}</p>
                             </LinkTo>
@@ -120,7 +120,7 @@ export const ExpenseStatusTabContent = (props: ExpenseSubscriptionProps) => {
                                             height={20}
                                             className="gap-3"
                                             textClassName="text-14 font-base font-normal"
-                                            isAlias={false}
+                                            isAlias={true}
                                         />
                                         <p>{currencyFormat(roundNumber(spend.amount))}</p>
                                     </LinkTo>
@@ -143,7 +143,7 @@ export const ExpenseStatusTabContent = (props: ExpenseSubscriptionProps) => {
                                 height={20}
                                 className="gap-3"
                                 textClassName="text-14 font-base font-normal"
-                                isAlias={false}
+                                isAlias={true}
                             />
                             <p>{currencyFormat(roundNumber(spend.amount))}</p>
                         </LinkTo>

--- a/src/clients/private/orgs/home/OrgDashboardPage/YearlySection/YearMonthlySubscriptionsSection/PaidSubscriptionSpendItem.tsx
+++ b/src/clients/private/orgs/home/OrgDashboardPage/YearlySection/YearMonthlySubscriptionsSection/PaidSubscriptionSpendItem.tsx
@@ -25,7 +25,7 @@ export const PaidSubscriptionSpendItem = memo((props: PaidSubscriptionSpendItemP
                     height={20}
                     className="gap-3"
                     textClassName="text-14 font-base font-normal"
-                    isAlias={false}
+                    isAlias={true}
                 />
                 <p className="whitespace-nowrap"> {amount > 0 ? currencyFormat(roundNumber(amount)) : '-'}</p>
             </LinkTo>

--- a/src/clients/private/orgs/reviewCampaigns/OrgReviewCampaignDetailPage/ReviewCampaignControl/DeleteReviewCampaignItem.tsx
+++ b/src/clients/private/orgs/reviewCampaigns/OrgReviewCampaignDetailPage/ReviewCampaignControl/DeleteReviewCampaignItem.tsx
@@ -10,10 +10,11 @@ import {OrgReviewCampaignListPageRoute} from '^pages/orgs/[id]/reviewCampaigns';
 
 interface DeleteReviewCampaignItemProps {
     reviewCampaign: ReviewCampaignDto;
+    reload?: () => void;
 }
 
 export const DeleteReviewCampaignItem = memo((props: DeleteReviewCampaignItemProps) => {
-    const {reviewCampaign} = props;
+    const {reviewCampaign, reload} = props;
     const router = useRouter();
 
     const onClick = async () => {
@@ -23,7 +24,13 @@ export const DeleteReviewCampaignItem = memo((props: DeleteReviewCampaignItemPro
         confirmed(confirmDestroy())
             .then(() => reviewCampaignApi.destroy(organizationId, id))
             .then(() => toast.success('요청을 삭제했어요.'))
-            .then(() => router.replace(OrgReviewCampaignListPageRoute.path(organizationId)))
+            .then(() => {
+                if (reload) {
+                    reload();
+                } else {
+                    router.replace(OrgReviewCampaignListPageRoute.path(organizationId));
+                }
+            })
             .catch(errorToast);
     };
 

--- a/src/clients/private/orgs/reviewCampaigns/OrgReviewCampaignListPage/RequestItemCard.tsx
+++ b/src/clients/private/orgs/reviewCampaigns/OrgReviewCampaignListPage/RequestItemCard.tsx
@@ -7,13 +7,17 @@ import {LinkTo} from '^components/util/LinkTo';
 import {OrgReviewCampaignDetailPageRoute} from '^pages/orgs/[id]/reviewCampaigns/[reviewCampaignId]';
 import {unitFormat} from '^utils/number';
 import {TagUI} from '^v3/share/table/columns/share/TagUI';
+import {DeleteReviewCampaignItem} from '^clients/private/orgs/reviewCampaigns/OrgReviewCampaignDetailPage/ReviewCampaignControl/DeleteReviewCampaignItem';
+import {MoreDropdown, MoreDropdownButton, MoreDropdownMenu} from '^_components/rest-pages/ShowPage/MoreDropdown';
+import {EllipsisVertical} from 'lucide-react';
 
 interface RequestItemCardProps {
     item: ReviewCampaignDto;
+    reload: () => void;
 }
 
 export const RequestItemCard = (props: RequestItemCardProps) => {
-    const {item: reviewCampaign} = props;
+    const {item: reviewCampaign, reload} = props;
     const {organizationId, id} = reviewCampaign;
 
     const isOverdue = reviewCampaign.isOverdue(); // 마감여부
@@ -31,18 +35,42 @@ export const RequestItemCard = (props: RequestItemCardProps) => {
                         {currentStatus.text}
                     </TagUI>
                     {/*<Badge className={cn('text-white px-2', badgeColor)}>{currentStatus.text}</Badge>*/}
-                    <div
-                        className={cn(
-                            `text-sm`,
-                            currentStatus.textColor,
-                            // isFinished ? 'text-gray-300' : 'text-slate-800',
+                    <div className="flex items-center gap-1">
+                        <div
+                            className={cn(
+                                `text-sm`,
+                                currentStatus.textColor,
+                                // isFinished ? 'text-gray-300' : 'text-slate-800',
+                            )}
+                        >
+                            {reviewCampaign.isClosed()
+                                ? `완료일: ${reviewCampaign.closedAt?.toLocaleDateString()}`
+                                : isOverdue
+                                ? `마감일: ${reviewCampaign.finishAt.toLocaleDateString()}`
+                                : `시작일: ${reviewCampaign.startAt.toLocaleDateString()}`}
+                        </div>
+                        {reviewCampaign && !reviewCampaign.isClosed() && (
+                            <MoreDropdown
+                                moreDropdownButton={() => (
+                                    <button
+                                        type="button"
+                                        onClick={(e) => {
+                                            e.preventDefault();
+                                        }}
+                                        aria-label="더보기"
+                                    >
+                                        <EllipsisVertical />
+                                    </button>
+                                )}
+                                noMenu
+                            >
+                                <MoreDropdownMenu className="!min-w-[8rem]">
+                                    {reviewCampaign && (
+                                        <DeleteReviewCampaignItem reviewCampaign={reviewCampaign} reload={reload} />
+                                    )}
+                                </MoreDropdownMenu>
+                            </MoreDropdown>
                         )}
-                    >
-                        {reviewCampaign.isClosed()
-                            ? `완료일: ${reviewCampaign.closedAt?.toLocaleDateString()}`
-                            : isOverdue
-                            ? `마감일: ${reviewCampaign.finishAt.toLocaleDateString()}`
-                            : `시작일: ${reviewCampaign.startAt.toLocaleDateString()}`}
                     </div>
                 </div>
 

--- a/src/clients/private/orgs/reviewCampaigns/OrgReviewCampaignListPage/index.tsx
+++ b/src/clients/private/orgs/reviewCampaigns/OrgReviewCampaignListPage/index.tsx
@@ -12,7 +12,7 @@ import {RequestItemCard} from './RequestItemCard';
 
 export const OrgReviewCampaignListPage = () => {
     const orgId = useIdParam('id');
-    const {search, result, movePage, isFetching} = useReviewCampaigns(orgId, {
+    const {search, result, movePage, isLoading, reload, setQuery} = useReviewCampaigns(orgId, {
         where: {organizationId: orgId},
         relations: ['organization', 'author'],
         order: {id: 'DESC'},
@@ -20,12 +20,11 @@ export const OrgReviewCampaignListPage = () => {
     const campaigns = result.items;
 
     const onSearch = debounce((keyword?: string) => {
-        return search((q) => ({
-            ...q,
+        return search({
             keyword,
             page: 1,
             order: {id: 'DESC'},
-        }));
+        });
     }, 500);
 
     return (
@@ -38,16 +37,16 @@ export const OrgReviewCampaignListPage = () => {
                     <ReviewCampaignCreateButton orgId={orgId} />
                 </>
             )}
-            ScopeHandler={<RequestScopeHandler search={search} />}
+            ScopeHandler={<RequestScopeHandler search={setQuery} />}
             onSearch={onSearch}
         >
-            {isFetching ? (
+            {isLoading ? (
                 <Spinner />
             ) : campaigns.length > 0 ? (
                 <>
                     <div className={'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4'}>
                         {campaigns.map((campaign) => (
-                            <RequestItemCard key={campaign.id} item={campaign} />
+                            <RequestItemCard key={campaign.id} item={campaign} reload={reload} />
                         ))}
                     </div>
                     {/* 하단 페이지네이션 */}

--- a/src/clients/private/orgs/reviewCampaigns/OrgReviewResponseEditPage/SubscriptionItemOfResponse.tsx
+++ b/src/clients/private/orgs/reviewCampaigns/OrgReviewResponseEditPage/SubscriptionItemOfResponse.tsx
@@ -71,10 +71,12 @@ export const SubscriptionItemOfResponse = memo((props: SubscriptionItemOfRespons
                     </div>
                     <section className="flex gap-1 text-gray-500 text-14">
                         {/* 결제수단 */}
-                        <span>
-                            {`${creditCardCompany || bankCompany || '알수없음'} 
-														(${creditCardEndNumber || bankEndNumber || ''})`}
-                        </span>
+                        <div>
+                            <span>{creditCardCompany || bankCompany || '-'}</span>
+                            {(creditCardEndNumber || bankEndNumber) && (
+                                <span>({creditCardEndNumber || bankEndNumber})</span>
+                            )}
+                        </div>
                         <span>|</span>
                         {/* 마지막 결제금액 */}
                         <div className="whitespace-nowrap flex gap-1">

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/BottomAction/BottomActionBar.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/BottomAction/BottomActionBar.tsx
@@ -7,10 +7,11 @@ import {RemoveTeamMembers} from './RemoveTeamMembers';
 
 interface BottomActionBarProps {
     checkboxHandler: CheckboxHandler<TeamMemberDto>;
+    reload: () => void;
 }
 
 export const BottomActionBar = memo((props: BottomActionBarProps) => {
-    const {checkboxHandler: ch} = props;
+    const {checkboxHandler: ch, reload} = props;
 
     const checkedItems = ch.checkedItems;
     const itemCount = checkedItems.length;
@@ -21,9 +22,9 @@ export const BottomActionBar = memo((props: BottomActionBarProps) => {
             <div className="flex flex-row gap-3 items-center px-6 py-1 bg-white rounded-full border border-gray-300 shadow-lg min-w-md">
                 <span className="text-gray-600">{itemCount}개 선택됨</span>
 
-                <InviteTeamMembers checkedItems={checkedItems} onClear={onClear} />
+                <InviteTeamMembers checkedItems={checkedItems} onClear={onClear} reload={reload} />
 
-                <RemoveTeamMembers checkedItems={checkedItems} onClear={onClear} />
+                <RemoveTeamMembers checkedItems={checkedItems} onClear={onClear} reload={reload} />
 
                 <RotateCcw className="text-gray-500 cursor-pointer hover:text-red-400" onClick={onClear} />
             </div>

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/BottomAction/RemoveTeamMembers.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/BottomAction/RemoveTeamMembers.tsx
@@ -6,23 +6,24 @@ import {toast} from 'react-hot-toast';
 import {allSettled} from '^utils/array';
 import {errorToast} from '^api/api';
 import {useOrgIdParam} from '^atoms/common';
-import {OrgTeamMemberListPageRoute} from '^pages/orgs/[id]/teamMembers';
 import {TeamMemberDto, useDeleteTeamMember} from '^models/TeamMember';
 import {ApprovalStatus, MembershipLevel} from '^models/Membership/types';
 import {confirmed} from '^components/util/dialog';
 import {confirm3} from '^components/util/dialog/confirm3';
+import {useTeamMemberDeleteTeamMember} from '^clients/private/orgs/team/team-members/OrgTeamMemberListPage/BottomAction/hooks';
 
 interface RemoveTeamMembersProps {
     checkedItems: TeamMemberDto[];
     onClear: () => void;
+    reload: () => void;
 }
 
 export const RemoveTeamMembers = memo((props: RemoveTeamMembersProps) => {
-    const {checkedItems, onClear} = props;
+    const {checkedItems, onClear, reload} = props;
     const orgId = useOrgIdParam();
     const router = useRouter();
 
-    const {mutateAsync: deleteTeamMember, isPending} = useDeleteTeamMember();
+    const {mutateAsync: deleteTeamMember, isPending} = useTeamMemberDeleteTeamMember(orgId);
 
     const isMemberOrOwner = (temMember: {membership?: {level?: MembershipLevel; approvalStatus?: ApprovalStatus}}) =>
         temMember.membership?.level === MembershipLevel.OWNER ||
@@ -46,22 +47,15 @@ export const RemoveTeamMembers = memo((props: RemoveTeamMembersProps) => {
             );
         };
 
-        return (
-            confirmed(removeConfirm())
-                .then(() => {
-                    const fetch = checkedItems.map((item) =>
-                        deleteTeamMember({
-                            orgId,
-                            id: item.id,
-                        }),
-                    );
-                    return allSettled(fetch);
-                })
-                // .then(() => router.replace(OrgTeamMemberListPageRoute.path(orgId)))
-                .then(() => toast.success('구성원을 삭제했어요.'))
-                .then(() => onClear())
-                .catch(errorToast)
-        );
+        return confirmed(removeConfirm())
+            .then(() => {
+                const fetch = checkedItems.map((item) => deleteTeamMember(item.id));
+                return allSettled(fetch);
+            })
+            .then(() => reload())
+            .then(() => toast.success('구성원을 삭제했어요.'))
+            .then(() => onClear())
+            .catch(errorToast);
     };
 
     return (

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/BottomAction/RemoveTeamMembers.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/BottomAction/RemoveTeamMembers.tsx
@@ -22,7 +22,7 @@ export const RemoveTeamMembers = memo((props: RemoveTeamMembersProps) => {
     const orgId = useOrgIdParam();
     const router = useRouter();
 
-    const {mutateAsync: deleteTeamMember} = useDeleteTeamMember();
+    const {mutateAsync: deleteTeamMember, isPending} = useDeleteTeamMember();
 
     const isMemberOrOwner = (temMember: {membership?: {level?: MembershipLevel; approvalStatus?: ApprovalStatus}}) =>
         temMember.membership?.level === MembershipLevel.OWNER ||
@@ -46,20 +46,22 @@ export const RemoveTeamMembers = memo((props: RemoveTeamMembersProps) => {
             );
         };
 
-        return confirmed(removeConfirm())
-            .then(() => {
-                const fetch = checkedItems.map((item) =>
-                    deleteTeamMember({
-                        orgId,
-                        id: item.id,
-                    }),
-                );
-                return allSettled(fetch);
-            })
-            .then(() => router.replace(OrgTeamMemberListPageRoute.path(orgId)))
-            .then(() => toast.success('구성원을 삭제했어요.'))
-            .then(() => onClear())
-            .catch(errorToast);
+        return (
+            confirmed(removeConfirm())
+                .then(() => {
+                    const fetch = checkedItems.map((item) =>
+                        deleteTeamMember({
+                            orgId,
+                            id: item.id,
+                        }),
+                    );
+                    return allSettled(fetch);
+                })
+                // .then(() => router.replace(OrgTeamMemberListPageRoute.path(orgId)))
+                .then(() => toast.success('구성원을 삭제했어요.'))
+                .then(() => onClear())
+                .catch(errorToast)
+        );
     };
 
     return (
@@ -73,7 +75,9 @@ export const RemoveTeamMembers = memo((props: RemoveTeamMembersProps) => {
                 </Tippy>
             ) : (
                 <button
-                    className="flex gap-1 btn btn-sm no-animation btn-animation btn-white !text-red-400"
+                    className={`flex gap-1 btn btn-sm no-animation btn-animation btn-white !text-red-400 ${
+                        !eachRemove && isPending ? 'link_to-loading' : ''
+                    }`}
                     onClick={onRemoveTeamMember}
                 >
                     <Trash2 />

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/BottomAction/hooks.ts
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/BottomAction/hooks.ts
@@ -1,0 +1,24 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {CreateMembershipInviteDto} from '^models/Membership/types';
+import {inviteMembershipApi} from '^models/Membership/api';
+import {TEAM_MEMBER_HOOK_KEY} from '^models/TeamMember/hook/key';
+import {teamMemberApi} from '^models/TeamMember';
+
+// 구성원 리스트페이지에서 다중으로 멤버를 삭제하는 경우 사용하는 훅
+export const useTeamMemberDeleteTeamMember = (orgId: number) => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (id: number) => teamMemberApi.destroy(orgId, id).then((res) => res.data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: [TEAM_MEMBER_HOOK_KEY.base], exact: false});
+        },
+    });
+};
+
+// 구성원 리스트페이지에서 다중으로 초대메일을 보낼 때 사용하는 훅
+export const useTeamMemberSendInviteEmail = () => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (data: CreateMembershipInviteDto) => inviteMembershipApi.create(data).then((res) => res.data),
+    });
+};

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/BottomAction/index.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/BottomAction/index.tsx
@@ -5,17 +5,18 @@ import {TeamMemberDto} from '^models/TeamMember';
 
 interface BottomActionProps {
     checkboxHandler: CheckboxHandler<TeamMemberDto>;
+    reload: () => void;
 }
 
 export const BottomAction = memo((props: BottomActionProps) => {
-    const {checkboxHandler} = props;
+    const {checkboxHandler, reload} = props;
 
     if (checkboxHandler.checkedItems.length === 0) return <></>;
 
     return (
         <div className="fixed inset-x-0 bottom-5 z-40 flex justify-center pointer-events-none">
             <div className="container px-4 pointer-events-auto">
-                <BottomActionBar checkboxHandler={checkboxHandler} />
+                <BottomActionBar checkboxHandler={checkboxHandler} reload={reload} />
             </div>
         </div>
     );

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/index.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/index.tsx
@@ -99,7 +99,7 @@ export const OrgTeamMemberListPage = memo(function OrgTeamMemberListPage() {
                     )}
                 />
             </ListTableContainer>
-            <BottomAction checkboxHandler={ch} />
+            <BottomAction checkboxHandler={ch} reload={reload} />
         </ListPage>
     );
 });

--- a/src/clients/private/orgs/team/teams/OrgTeamDetailPage/Subscriptions/TeamSubscriptionCard.tsx
+++ b/src/clients/private/orgs/team/teams/OrgTeamDetailPage/Subscriptions/TeamSubscriptionCard.tsx
@@ -7,19 +7,23 @@ import {LinkTo} from '^components/util/LinkTo';
 
 interface TeamSubscriptionCardProps {
     item: SubscriptionDto;
+    onClick: () => void;
 }
 
 export const TeamSubscriptionCard = memo((props: TeamSubscriptionCardProps) => {
-    const {item: subscription} = props;
+    const {item: subscription, onClick} = props;
 
     const {product, teamMembers = []} = subscription;
 
     const memberMaxLength = 3;
 
     return (
-        <li className="w-full border bg-white rounded-lg flex items-center shadow-xl hover:shadow-2xl">
-            <LinkTo
-                href={OrgSubscriptionDetailPageRoute.path(subscription.organizationId, subscription.id)}
+        <li
+            className="w-full border bg-white rounded-lg flex items-center shadow-xl hover:shadow-2xl cursor-pointer"
+            onClick={onClick}
+        >
+            <div
+                // href={OrgSubscriptionDetailPageRoute.path(subscription.organizationId, subscription.id)}
                 className="w-full flex items-center justify-between p-4"
             >
                 <SubscriptionProfile
@@ -44,7 +48,7 @@ export const TeamSubscriptionCard = memo((props: TeamSubscriptionCardProps) => {
                         </div>
                     )}
                 </div>
-            </LinkTo>
+            </div>
         </li>
     );
 });

--- a/src/clients/private/orgs/team/teams/OrgTeamDetailPage/Subscriptions/TeamSubscriptionsListPage.tsx
+++ b/src/clients/private/orgs/team/teams/OrgTeamDetailPage/Subscriptions/TeamSubscriptionsListPage.tsx
@@ -22,7 +22,7 @@ export const TeamSubscriptionsListPage = memo(function (props: OrgTeamDetailPage
     const [selectedSubscription, setSelectedSubscription] = useState<SubscriptionDto | null>(null);
 
     const {search, result, isLoading} = useTeamSubscriptions2(orgId, teamId, {
-        relations: ['product', 'teamMembers'],
+        relations: ['product', 'teamMembers', 'bankAccount', 'creditCard'],
         itemsPerPage: 0,
     });
 

--- a/src/clients/private/orgs/team/teams/OrgTeamDetailPage/Subscriptions/TeamSubscriptionsListPage.tsx
+++ b/src/clients/private/orgs/team/teams/OrgTeamDetailPage/Subscriptions/TeamSubscriptionsListPage.tsx
@@ -1,4 +1,4 @@
-import React, {memo} from 'react';
+import React, {memo, useState} from 'react';
 import {debounce} from 'lodash';
 import {useIdParam, useOrgIdParam} from '^atoms/common';
 import {useCurrentTeam} from '^models/Team/hook';
@@ -11,13 +11,15 @@ import {EmptyTable} from '^_components/table/EmptyTable';
 import {Inbox} from 'lucide-react';
 import {useRouter} from 'next/router';
 import {OrgSubscriptionListPageRoute} from '^pages/orgs/[id]/subscriptions';
+import {TeamSubscriptionDetailModal} from '^clients/private/orgs/team/teams/OrgTeamDetailPage/Subscriptions/teamSubscriptionDetailModal/TeamSubscriptionDetailModal';
+import {SubscriptionDto} from '^models/Subscription/types';
 
 export const TeamSubscriptionsListPage = memo(function (props: OrgTeamDetailPageTabContentCommonProps) {
     const {reload: reloadParent} = props;
     const {team} = useCurrentTeam();
     const orgId = useOrgIdParam();
     const teamId = useIdParam('teamId');
-    const router = useRouter();
+    const [selectedSubscription, setSelectedSubscription] = useState<SubscriptionDto | null>(null);
 
     const {search, result, isLoading} = useTeamSubscriptions2(orgId, teamId, {
         relations: ['product', 'teamMembers'],
@@ -48,10 +50,19 @@ export const TeamSubscriptionsListPage = memo(function (props: OrgTeamDetailPage
                     <div className="w-full">
                         <ul className="grid grid-cols-3 gap-x-2 gap-y-3">
                             {result.items.map((item) => (
-                                <TeamSubscriptionCard item={item} key={item.id} />
+                                <TeamSubscriptionCard
+                                    item={item}
+                                    key={item.id}
+                                    onClick={() => setSelectedSubscription(item)}
+                                />
                             ))}
                         </ul>
                     </div>
+                    <TeamSubscriptionDetailModal
+                        subscription={selectedSubscription}
+                        onClose={() => setSelectedSubscription(null)}
+                        isOpened={!!selectedSubscription}
+                    />
                 </LoadableBox>
             </>
         );

--- a/src/clients/private/orgs/team/teams/OrgTeamDetailPage/Subscriptions/teamSubscriptionDetailModal/TeamSubscriptionDetailModal.tsx
+++ b/src/clients/private/orgs/team/teams/OrgTeamDetailPage/Subscriptions/teamSubscriptionDetailModal/TeamSubscriptionDetailModal.tsx
@@ -1,18 +1,12 @@
 import React, {memo} from 'react';
 import {SubscriptionDto} from '^models/Subscription/types';
 import {BasicModal} from '^components/modals/_shared/BasicModal';
-import {HelpCircle, X} from 'lucide-react';
-import {SubscriptionProfile, SubscriptionUsingStatusTag} from '^models/Subscription/components';
+import {X} from 'lucide-react';
 import {LinkTo} from '^components/util/LinkTo';
 import {OrgSubscriptionDetailPageRoute} from '^pages/orgs/[id]/subscriptions/[subscriptionId]';
-import {Avatar} from '^components/Avatar';
-import {t_SubscriptionBillingCycleType} from '^models/Subscription/types/BillingCycleOptions';
-import {useRecoilValue} from 'recoil';
-import {displayCurrencyAtom} from '^tasting/pageAtoms';
-import {yyyy_mm_dd} from '^utils/dateTime';
-import {getCurrencySymbol} from '^api/tasting.api/gmail/agent/parse-email-price';
-import {currencyFormat} from '^utils/number';
 import {TeamMemberProfile} from '^models/TeamMember/components/TeamMemberProfile';
+import {useCurrentTeam} from '^models/Team/hook';
+import {SubscriptionDetailProfile} from '^models/Subscription/components/SubscriptionDetailProfile';
 
 interface TeamSubscriptionDetailModalProps {
     isOpened: boolean;
@@ -22,74 +16,41 @@ interface TeamSubscriptionDetailModalProps {
 
 export const TeamSubscriptionDetailModal = memo((props: TeamSubscriptionDetailModalProps) => {
     const {isOpened, onClose, subscription} = props;
-    const displayCurrency = useRecoilValue(displayCurrencyAtom);
+    const {team} = useCurrentTeam();
+
+    console.log(team);
 
     if (!subscription) return <></>;
 
-    const {product, teamMembers, billingCycleType, bankAccount, creditCard, currentBillingAmount} = subscription;
+    const {teamMembers} = subscription;
     if (!teamMembers) return <></>;
-
-    const lastPaidAt = subscription.lastPaidAt ? yyyy_mm_dd(new Date(subscription.lastPaidAt)) : '-';
-
-    const creditCardCompany = creditCard?.company?.displayName;
-    const creditCardEndNumber = creditCard?.secretInfo?.number4;
-
-    const bankCompany = bankAccount?.bankName;
-    const bankEndNumber = bankAccount?.endNumber();
-
-    const symbol = getCurrencySymbol(displayCurrency);
-    const billingAmount = currentBillingAmount?.amount ? currentBillingAmount.toDisplayPrice(displayCurrency) : 0;
 
     return (
         <BasicModal open={isOpened} onClose={onClose}>
             <div className="flex flex-col gap-5 justify-between p-8 max-w-xl modal-box keep-all">
-                <section className="flex flex-col gap-3 w-full">
+                <section className="flex flex-col gap-1 w-full">
                     <div className="flex justify-between items-start w-full">
-                        <header className="font-semibold text-20">구독에 연결된 팀멤버 </header>
+                        <header className="font-semibold text-20">구독을 이용중인 팀 멤버 </header>
                         <X className="cursor-pointer size-6" onClick={onClose} />
                     </div>
-                    <div className="flex items-start gap-6">
-                        <Avatar
-                            className="w-14 h-14"
-                            src={product.image}
-                            alt={product.name()}
-                            draggable={false}
-                            loading="lazy"
-                        >
-                            <HelpCircle size={24} className="text-gray-300 h-full w-full p-[6px]" />
-                        </Avatar>
-                        <div className="flex flex-col gap-0.5 overflow-hidden text-left">
-                            <p className="flex gap-2 text-18 font-semibold items-center group-hover:text-scordi leading-none py-1">
-                                <span className="truncate">{product.name()}</span>
-                            </p>
-
-                            <section className="flex gap-1 text-gray-500 text-14 items-center">
-                                {/* 별칭 */}
-                                <p className="block text-14 font-normal text-gray-400 group-hover:text-scordi-300 leading-none">
-                                    {subscription.alias ? subscription.alias : '-'}
-                                </p>
-                                <span>|</span>
-
-                                {/* 마지막 결제금액 */}
-                                <div className="whitespace-nowrap flex gap-1">
-                                    <span>{symbol}</span>
-                                    <span>{currencyFormat(billingAmount, '')}</span>
-                                </div>
-                            </section>
-                        </div>
+                    <div className="pb-2 pt-3">
+                        <SubscriptionDetailProfile
+                            subscription={subscription}
+                            imageClassName="w-14 h-14"
+                            tempImageSize={56}
+                        />
                     </div>
                 </section>
                 <section className="flex flex-col w-full">
                     <div className="flex overflow-y-auto flex-col gap-4 py-3 w-full max-h-80 border-t border-gray-300">
                         <span>
-                            {' '}
-                            총 <b>{teamMembers.length}</b>명의 멤버가 사용중입니다.
+                            <b>{team?.name}</b>에서 총<b>{teamMembers.length}</b>명의 멤버가 쓰고 있어요.
                         </span>
                     </div>
 
                     <ul className="flex overflow-y-auto flex-col gap-4 py-3 w-full max-h-80 border-t border-b border-gray-300">
                         {teamMembers.map((teamMember) => (
-                            <TeamMemberProfile item={teamMember} />
+                            <TeamMemberProfile key={teamMember.id} item={teamMember} />
                         ))}
                     </ul>
                 </section>
@@ -97,7 +58,7 @@ export const TeamSubscriptionDetailModal = memo((props: TeamSubscriptionDetailMo
                     href={OrgSubscriptionDetailPageRoute.path(subscription.organizationId, subscription.id)}
                     className="btn btn-md text-16 btn-scordi"
                 >
-                    구독 상세 바로가기
+                    구독을 이용중인 전체 멤버 확인하기
                 </LinkTo>
             </div>
         </BasicModal>

--- a/src/clients/private/orgs/team/teams/OrgTeamDetailPage/Subscriptions/teamSubscriptionDetailModal/TeamSubscriptionDetailModal.tsx
+++ b/src/clients/private/orgs/team/teams/OrgTeamDetailPage/Subscriptions/teamSubscriptionDetailModal/TeamSubscriptionDetailModal.tsx
@@ -1,0 +1,105 @@
+import React, {memo} from 'react';
+import {SubscriptionDto} from '^models/Subscription/types';
+import {BasicModal} from '^components/modals/_shared/BasicModal';
+import {HelpCircle, X} from 'lucide-react';
+import {SubscriptionProfile, SubscriptionUsingStatusTag} from '^models/Subscription/components';
+import {LinkTo} from '^components/util/LinkTo';
+import {OrgSubscriptionDetailPageRoute} from '^pages/orgs/[id]/subscriptions/[subscriptionId]';
+import {Avatar} from '^components/Avatar';
+import {t_SubscriptionBillingCycleType} from '^models/Subscription/types/BillingCycleOptions';
+import {useRecoilValue} from 'recoil';
+import {displayCurrencyAtom} from '^tasting/pageAtoms';
+import {yyyy_mm_dd} from '^utils/dateTime';
+import {getCurrencySymbol} from '^api/tasting.api/gmail/agent/parse-email-price';
+import {currencyFormat} from '^utils/number';
+import {TeamMemberProfile} from '^models/TeamMember/components/TeamMemberProfile';
+
+interface TeamSubscriptionDetailModalProps {
+    isOpened: boolean;
+    onClose: () => void;
+    subscription: SubscriptionDto | null;
+}
+
+export const TeamSubscriptionDetailModal = memo((props: TeamSubscriptionDetailModalProps) => {
+    const {isOpened, onClose, subscription} = props;
+    const displayCurrency = useRecoilValue(displayCurrencyAtom);
+
+    if (!subscription) return <></>;
+
+    const {product, teamMembers, billingCycleType, bankAccount, creditCard, currentBillingAmount} = subscription;
+    if (!teamMembers) return <></>;
+
+    const lastPaidAt = subscription.lastPaidAt ? yyyy_mm_dd(new Date(subscription.lastPaidAt)) : '-';
+
+    const creditCardCompany = creditCard?.company?.displayName;
+    const creditCardEndNumber = creditCard?.secretInfo?.number4;
+
+    const bankCompany = bankAccount?.bankName;
+    const bankEndNumber = bankAccount?.endNumber();
+
+    const symbol = getCurrencySymbol(displayCurrency);
+    const billingAmount = currentBillingAmount?.amount ? currentBillingAmount.toDisplayPrice(displayCurrency) : 0;
+
+    return (
+        <BasicModal open={isOpened} onClose={onClose}>
+            <div className="flex flex-col gap-5 justify-between p-8 max-w-xl modal-box keep-all">
+                <section className="flex flex-col gap-3 w-full">
+                    <div className="flex justify-between items-start w-full">
+                        <header className="font-semibold text-20">구독에 연결된 팀멤버 </header>
+                        <X className="cursor-pointer size-6" onClick={onClose} />
+                    </div>
+                    <div className="flex items-start gap-6">
+                        <Avatar
+                            className="w-14 h-14"
+                            src={product.image}
+                            alt={product.name()}
+                            draggable={false}
+                            loading="lazy"
+                        >
+                            <HelpCircle size={24} className="text-gray-300 h-full w-full p-[6px]" />
+                        </Avatar>
+                        <div className="flex flex-col gap-0.5 overflow-hidden text-left">
+                            <p className="flex gap-2 text-18 font-semibold items-center group-hover:text-scordi leading-none py-1">
+                                <span className="truncate">{product.name()}</span>
+                            </p>
+
+                            <section className="flex gap-1 text-gray-500 text-14 items-center">
+                                {/* 별칭 */}
+                                <p className="block text-14 font-normal text-gray-400 group-hover:text-scordi-300 leading-none">
+                                    {subscription.alias ? subscription.alias : '-'}
+                                </p>
+                                <span>|</span>
+
+                                {/* 마지막 결제금액 */}
+                                <div className="whitespace-nowrap flex gap-1">
+                                    <span>{symbol}</span>
+                                    <span>{currencyFormat(billingAmount, '')}</span>
+                                </div>
+                            </section>
+                        </div>
+                    </div>
+                </section>
+                <section className="flex flex-col w-full">
+                    <div className="flex overflow-y-auto flex-col gap-4 py-3 w-full max-h-80 border-t border-gray-300">
+                        <span>
+                            {' '}
+                            총 <b>{teamMembers.length}</b>명의 멤버가 사용중입니다.
+                        </span>
+                    </div>
+
+                    <ul className="flex overflow-y-auto flex-col gap-4 py-3 w-full max-h-80 border-t border-b border-gray-300">
+                        {teamMembers.map((teamMember) => (
+                            <TeamMemberProfile item={teamMember} />
+                        ))}
+                    </ul>
+                </section>
+                <LinkTo
+                    href={OrgSubscriptionDetailPageRoute.path(subscription.organizationId, subscription.id)}
+                    className="btn btn-md text-16 btn-scordi"
+                >
+                    구독 상세 바로가기
+                </LinkTo>
+            </div>
+        </BasicModal>
+    );
+});

--- a/src/clients/private/orgs/team/teams/OrgTeamDetailPage/index.tsx
+++ b/src/clients/private/orgs/team/teams/OrgTeamDetailPage/index.tsx
@@ -1,5 +1,5 @@
 import React, {memo, useEffect, useState} from 'react';
-import {useRecoilState, useRecoilValue} from 'recoil';
+import {useRecoilState, useRecoilValue, useSetRecoilState} from 'recoil';
 import {orgIdParamState, teamIdParamState, useIdParam, useOrgIdParam} from '^atoms/common';
 import {OrgTeamListPageRoute} from '^pages/orgs/[id]/teams';
 import {useCurrentTeam, useCurrentTeam2} from '^models/Team/hook';
@@ -9,6 +9,7 @@ import {TeamProfileSection} from './TeamProfileSection';
 import {TeamStatCardList} from './TeamStatCardList';
 import {OrgTeamDetailPageTabContent, TabName} from './OrgTeamDetailPageTabContent';
 import {useUnmount} from '^hooks/useUnmount';
+import {currentTeamAtom} from '^models/Team/atom';
 
 export const OrgTeamDetailPage = memo(function OrgTeamDetailPage() {
     const orgId = useOrgIdParam();
@@ -17,6 +18,11 @@ export const OrgTeamDetailPage = memo(function OrgTeamDetailPage() {
     const [tab, setTab] = useState(TabName.members);
 
     const {data: currentTeamData} = useCurrentTeam2(orgId, teamId);
+    const setTeam = useSetRecoilState(currentTeamAtom);
+
+    useEffect(() => {
+        setTeam(currentTeamData);
+    }, [orgId, currentTeamData]);
 
     return (
         <MainLayout>

--- a/src/models/ReviewCampaign/hook/index.tsx
+++ b/src/models/ReviewCampaign/hook/index.tsx
@@ -5,6 +5,7 @@ import {useState} from 'react';
 import {Paginated} from '^types/utils/paginated.dto';
 import {FindAllReviewCampaignSubscriptionsQueryDto} from '../type';
 import {FindAllReviewResponseSubscriptionsQueryDto} from '^models/ReviewResponse/type';
+import {usePaginateUtils} from '^hooks/usePagedResource';
 
 export const useReviewCampaigns = (orgId: number, params: FindAllReviewCampaignsQueryDto = {}) => {
     const [query, setQuery] = useState(params);
@@ -19,13 +20,7 @@ export const useReviewCampaigns = (orgId: number, params: FindAllReviewCampaigns
         return setQuery((q) => ({...q, page}));
     };
 
-    return {
-        ...queryResult,
-        query,
-        result: queryResult.data,
-        search: setQuery,
-        movePage,
-    };
+    return usePaginateUtils({query, setQuery, queryResult});
 };
 
 export const useReviewCampaign = (orgId: number, id: number) => {

--- a/src/models/Subscription/components/SubscriptionDetailProfile.tsx
+++ b/src/models/Subscription/components/SubscriptionDetailProfile.tsx
@@ -1,0 +1,87 @@
+import React, {memo} from 'react';
+import {SubscriptionDto} from '^models/Subscription/types';
+import {yyyy_mm_dd} from '^utils/dateTime';
+import {getCurrencySymbol} from '^api/tasting.api/gmail/agent/parse-email-price';
+import {useRecoilValue} from 'recoil';
+import {displayCurrencyAtom} from '^tasting/pageAtoms';
+import {NextImage} from '^components/NextImage';
+import {HelpCircle} from 'lucide-react';
+import {t_SubscriptionBillingCycleType} from '^models/Subscription/types/BillingCycleOptions';
+import {currencyFormat} from '^utils/number';
+import {Avatar} from '^components/Avatar';
+
+interface SubscriptionDetailProfileProps {
+    subscription: SubscriptionDto;
+    imageClassName: string;
+    tempImageSize: number;
+}
+
+export const SubscriptionDetailProfile = memo((props: SubscriptionDetailProfileProps) => {
+    const {subscription, imageClassName, tempImageSize} = props;
+
+    const displayCurrency = useRecoilValue(displayCurrencyAtom);
+    const {product, billingCycleType, bankAccount, creditCard, currentBillingAmount} = subscription;
+
+    const lastPaidAt = subscription.lastPaidAt ? yyyy_mm_dd(new Date(subscription.lastPaidAt)) : '-';
+
+    const creditCardCompany = creditCard?.company?.displayName;
+    const creditCardEndNumber = creditCard?.secretInfo?.number4;
+
+    const bankCompany = bankAccount?.bankName;
+    const bankEndNumber = bankAccount?.endNumber();
+
+    const symbol = getCurrencySymbol(displayCurrency);
+    const billingAmount = currentBillingAmount?.amount ? currentBillingAmount.toDisplayPrice(displayCurrency) : 0;
+
+    return (
+        <div className="flex justify-between items-center rounded-lg cursor-pointer text-16 hover:bg-primaryColor-bg">
+            <div className="flex gap-4 items-center">
+                <section className={`flex gap-1 flex-row items-center ${imageClassName}`}>
+                    <Avatar
+                        className={imageClassName}
+                        src={product.image}
+                        alt={product.name()}
+                        draggable={false}
+                        loading="lazy"
+                    >
+                        <HelpCircle size={tempImageSize} className="text-gray-300 h-full w-full p-[6px]" />
+                    </Avatar>
+                </section>
+                <div className="flex flex-col">
+                    <section>
+                        <span className="font-semibold text-gray-900 whitespace-nowrap">{product.name()}</span>
+
+                        {subscription.alias && (
+                            <>
+                                <span>-</span>
+                                <span className="block text-14 font-normal text-gray-400 group-hover:text-scordi-300 leading-none">
+                                    {subscription.alias}
+                                </span>
+                            </>
+                        )}
+                    </section>
+
+                    <section className="flex gap-1 text-gray-500 text-14">
+                        {/* 결제 주기 */}
+                        <span>{t_SubscriptionBillingCycleType(billingCycleType, true)} |</span>
+
+                        {/* 마지막 결제일 */}
+                        <span>{lastPaidAt} |</span>
+
+                        {/* 결제수단 */}
+                        <div>
+                            <span>{creditCardCompany || bankCompany || '-'}</span>
+                            {(creditCardEndNumber || bankEndNumber) && (
+                                <span>{`${creditCardEndNumber || bankEndNumber}`}</span>
+                            )}
+                        </div>
+                    </section>
+                </div>
+            </div>
+            <div className="font-semibold text-gray-900 whitespace-nowrap flex gap-1">
+                <span>{symbol}</span>
+                <span>{currencyFormat(billingAmount, '')}</span>
+            </div>
+        </div>
+    );
+});


### PR DESCRIPTION
## Description

<!-- PR에 포함된 변경사항을 간략하게 작성해 주세요. -->
- 팀상세/구독탭에서 구독 클릭 시 팀 리스트가 보이는 모달 추가 
- 요청리스트 페이지에 삭제기능 추가 
- 구성원 초대 시 계정이 중복 생성되는데 id를 보내지 않아서 생겼던 버그 수정 및 로딩 상태 추가
- 홈 대시보드에서 구독이 보이는 영역은 별칭이 뜰 수 있도록 추가 
- 결제내역 수동등록 모달에 서비스명에 별칭이 보일 수 있도록 수정 
